### PR TITLE
Layer: calculate node_and_value_count non-recursive

### DIFF
--- a/src/layer/base.rs
+++ b/src/layer/base.rs
@@ -97,6 +97,10 @@ impl<M:'static+AsRef<[u8]>+Clone+Send+Sync> Layer for BaseLayer<M> {
         self.node_dictionary.len()
     }
 
+    fn predicate_dict_len(&self) -> usize {
+        self.predicate_dictionary.len()
+    }
+
     fn value_dict_len(&self) -> usize {
         self.value_dictionary.len()
     }

--- a/src/layer/base.rs
+++ b/src/layer/base.rs
@@ -93,6 +93,14 @@ impl<M:'static+AsRef<[u8]>+Clone+Send+Sync> Layer for BaseLayer<M> {
         Box::new(std::iter::empty())
     }
 
+    fn node_dict_len(&self) -> usize {
+        self.node_dictionary.len()
+    }
+
+    fn value_dict_len(&self) -> usize {
+        self.value_dictionary.len()
+    }
+
     fn node_and_value_count(&self) -> usize {
         self.node_dictionary.len() + self.value_dictionary.len()
     }

--- a/src/layer/child.rs
+++ b/src/layer/child.rs
@@ -187,8 +187,18 @@ impl<M:'static+AsRef<[u8]>+Clone+Send+Sync> Layer for ChildLayer<M> {
         count
     }
 
+    fn predicate_dict_len(&self) -> usize {
+        self.predicate_dictionary.len()
+    }
+
     fn predicate_count(&self) -> usize {
-        self.predicate_dictionary.len() + self.parent.predicate_count()
+        let mut parent_option = self.parent();
+        let mut count = self.predicate_dictionary.len();
+        while let Some(parent) = parent_option {
+            count += parent.predicate_dict_len();
+            parent_option = parent.parent();
+        }
+        count
     }
 
     fn subject_id(&self, subject: &str) -> Option<u64> {

--- a/src/layer/child.rs
+++ b/src/layer/child.rs
@@ -184,7 +184,7 @@ impl<M:'static+AsRef<[u8]>+Clone+Send+Sync> Layer for ChildLayer<M> {
             count += parent.node_dict_len() + parent.value_dict_len();
             parent_option = parent.parent();
         }
-        return count;
+        count
     }
 
     fn predicate_count(&self) -> usize {

--- a/src/layer/child.rs
+++ b/src/layer/child.rs
@@ -178,12 +178,11 @@ impl<M:'static+AsRef<[u8]>+Clone+Send+Sync> Layer for ChildLayer<M> {
     }
 
     fn node_and_value_count(&self) -> usize {
-        let mut parent = self.parent();
+        let mut parent_option = self.parent();
         let mut count = self.node_dictionary.len() + self.value_dictionary.len();
-        while parent.is_some() {
-            let par_unwrap = parent.unwrap();
-            count += par_unwrap.node_dict_len() + par_unwrap.value_dict_len();
-            parent = par_unwrap.parent();
+        while let Some(parent) = parent_option {
+            count += parent.node_dict_len() + parent.value_dict_len();
+            parent_option = parent.parent();
         }
         return count;
     }

--- a/src/layer/child.rs
+++ b/src/layer/child.rs
@@ -169,8 +169,23 @@ impl<M:'static+AsRef<[u8]>+Clone+Send+Sync> Layer for ChildLayer<M> {
         Some(self.parent.clone())
     }
 
+    fn node_dict_len(&self) -> usize {
+        self.node_dictionary.len()
+    }
+
+    fn value_dict_len(&self) -> usize {
+        self.value_dictionary.len()
+    }
+
     fn node_and_value_count(&self) -> usize {
-        self.node_dictionary.len() + self.value_dictionary.len() + self.parent.node_and_value_count()
+        let mut parent = self.parent();
+        let mut count = self.node_dictionary.len() + self.value_dictionary.len();
+        while parent.is_some() {
+            let par_unwrap = parent.unwrap();
+            count += par_unwrap.node_dict_len() + par_unwrap.value_dict_len();
+            parent = par_unwrap.parent();
+        }
+        return count;
     }
 
     fn predicate_count(&self) -> usize {

--- a/src/layer/layer.rs
+++ b/src/layer/layer.rs
@@ -21,6 +21,10 @@ pub trait Layer: Send+Sync {
     /// The amount of predicates known to this layer.
     /// This also counts entries in the parent.
     fn predicate_count(&self) -> usize;
+    /// Node dict length of this specific layer
+    fn node_dict_len(&self) -> usize;
+    /// Value dict length of this specific layer
+    fn value_dict_len(&self) -> usize;
 
     /// The numerical id of a subject, or None if the subject cannot be found.
     fn subject_id(&self, subject: &str) -> Option<u64>;

--- a/src/layer/layer.rs
+++ b/src/layer/layer.rs
@@ -21,6 +21,8 @@ pub trait Layer: Send+Sync {
     /// The amount of predicates known to this layer.
     /// This also counts entries in the parent.
     fn predicate_count(&self) -> usize;
+    /// Predicate dict length of this specific layer
+    fn predicate_dict_len(&self) -> usize;
     /// Node dict length of this specific layer
     fn node_dict_len(&self) -> usize;
     /// Value dict length of this specific layer

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -165,6 +165,10 @@ impl Layer for StoreLayer {
         self.layer.value_dict_len()
     }
 
+    fn predicate_dict_len(&self) -> usize {
+        self.layer.predicate_dict_len()
+    }
+
     fn predicate_count(&self) -> usize {
         self.layer.predicate_count()
     }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -157,6 +157,14 @@ impl Layer for StoreLayer {
         self.layer.node_and_value_count()
     }
 
+    fn node_dict_len(&self) -> usize {
+        self.layer.node_dict_len()
+    }
+
+    fn value_dict_len(&self) -> usize {
+        self.layer.value_dict_len()
+    }
+
     fn predicate_count(&self) -> usize {
         self.layer.predicate_count()
     }

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -140,6 +140,10 @@ impl Layer for SyncStoreLayer {
         self.inner.node_and_value_count()
     }
 
+    fn predicate_dict_len(&self) -> usize {
+        self.inner.predicate_dict_len()
+    }
+
     fn predicate_count(&self) -> usize {
         self.inner.predicate_count()
     }

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -128,6 +128,14 @@ impl Layer for SyncStoreLayer {
         (&self.inner as &dyn Layer).parent()
     }
 
+    fn node_dict_len(&self) -> usize {
+        self.inner.node_dict_len()
+    }
+
+    fn value_dict_len(&self) -> usize {
+        self.inner.value_dict_len()
+    }
+
     fn node_and_value_count(&self) -> usize {
         self.inner.node_and_value_count()
     }


### PR DESCRIPTION
Calculate the node_and_value count in a more imperative way for better performance and a smaller stack.