### PR TITLE
pfc: Replace panic with Option

### DIFF
--- a/src/layer/base.rs
+++ b/src/layer/base.rs
@@ -102,15 +102,15 @@ impl<M:'static+AsRef<[u8]>+Clone+Send+Sync> Layer for BaseLayer<M> {
         self.node_dictionary.len()
     }
 
-    fn node_dict_get(&self, id: usize) -> String {
+    fn node_dict_get(&self, id: usize) -> Option<String> {
         self.node_dictionary.get(id)
     }
 
-    fn predicate_dict_get(&self, id: usize) -> String {
+    fn predicate_dict_get(&self, id: usize) -> Option<String> {
         self.predicate_dictionary.get(id)
     }
 
-    fn value_dict_get(&self, id: usize) -> String {
+    fn value_dict_get(&self, id: usize) -> Option<String> {
         self.value_dictionary.get(id)
     }
 
@@ -164,11 +164,7 @@ impl<M:'static+AsRef<[u8]>+Clone+Send+Sync> Layer for BaseLayer<M> {
             return None;
         }
         let corrected_id = id - 1;
-
-        match corrected_id < (self.node_dictionary.len() as u64) {
-            true => Some(self.node_dictionary.get(corrected_id as usize)),
-            false => None
-        }
+        self.node_dict_get(corrected_id as usize)
     }
 
     fn id_predicate(&self, id: u64) -> Option<String> {
@@ -176,11 +172,7 @@ impl<M:'static+AsRef<[u8]>+Clone+Send+Sync> Layer for BaseLayer<M> {
             return None;
         }
         let corrected_id = id - 1;
-
-        match corrected_id < (self.predicate_dictionary.len() as u64) {
-            true => Some(self.predicate_dictionary.get(corrected_id as usize)),
-            false => None
-        }
+        self.predicate_dict_get(corrected_id as usize)
     }
 
     fn id_object(&self, id: u64) -> Option<ObjectType> {
@@ -191,15 +183,10 @@ impl<M:'static+AsRef<[u8]>+Clone+Send+Sync> Layer for BaseLayer<M> {
 
         if corrected_id >= (self.node_dictionary.len() as u64) {
             let val_id = corrected_id - (self.node_dictionary.len() as u64);
-            if val_id >= (self.value_dictionary.len() as u64) {
-                None
-            }
-            else {
-                Some(ObjectType::Value(self.value_dictionary.get(val_id as usize)))
-            }
+            self.value_dict_get(val_id as usize).map(ObjectType::Value)
         }
         else {
-            Some(ObjectType::Node(self.node_dictionary.get(corrected_id as usize)))
+            self.node_dictionary.get(corrected_id as usize).map(ObjectType::Node)
         }
     }
 

--- a/src/layer/child.rs
+++ b/src/layer/child.rs
@@ -188,12 +188,12 @@ impl<M:'static+AsRef<[u8]>+Clone+Send+Sync> Layer for ChildLayer<M> {
         self.node_dictionary.len()
     }
 
-    fn node_dict_get(&self, id: usize) -> String {
+    fn node_dict_get(&self, id: usize) -> Option<String> {
         self.node_dictionary.get(id)
     }
 
 
-    fn value_dict_get(&self, id: usize) -> String {
+    fn value_dict_get(&self, id: usize) -> Option<String> {
         self.value_dictionary.get(id)
     }
 
@@ -223,7 +223,7 @@ impl<M:'static+AsRef<[u8]>+Clone+Send+Sync> Layer for ChildLayer<M> {
         self.predicate_dictionary.id(predicate)
     }
 
-    fn predicate_dict_get(&self, id: usize) -> String {
+    fn predicate_dict_get(&self, id: usize) -> Option<String> {
         self.predicate_dictionary.get(id)
     }
 
@@ -320,12 +320,7 @@ impl<M:'static+AsRef<[u8]>+Clone+Send+Sync> Layer for ChildLayer<M> {
             if corrected_id >= parent_count as u64 {
                 // subject, if it exists, is in this layer
                 corrected_id -= parent_count;
-                if corrected_id >= current_layer.node_dict_len() as u64 {
-                    return None
-                }
-                else {
-                    return Some(current_layer.node_dict_get(corrected_id as usize))
-                }
+                return current_layer.node_dict_get(corrected_id as usize);
             }
             else {
                 current_option = current_layer.parent();
@@ -350,12 +345,7 @@ impl<M:'static+AsRef<[u8]>+Clone+Send+Sync> Layer for ChildLayer<M> {
             if corrected_id >= parent_count as u64 {
                 // subject, if it exists, is in this layer
                 corrected_id -= parent_count;
-                if corrected_id >= current_layer.predicate_dict_len() as u64 {
-                    return None
-                }
-                else {
-                    return Some(current_layer.predicate_dict_get(corrected_id as usize))
-                }
+                return current_layer.predicate_dict_get(corrected_id as usize);
             }
             else {
                 current_option = current_layer.parent();
@@ -384,15 +374,10 @@ impl<M:'static+AsRef<[u8]>+Clone+Send+Sync> Layer for ChildLayer<M> {
                 if corrected_id >= current_layer.node_dict_len() as u64 {
                     // object, if it exists, must be a value
                     corrected_id -= current_layer.node_dict_len() as u64;
-                    if corrected_id >= current_layer.value_dict_len() as u64 {
-                        return None;
-                    }
-                    else {
-                        return Some(ObjectType::Value(current_layer.value_dict_get(corrected_id as usize)));
-                    }
+                    return current_layer.value_dict_get(corrected_id as usize).map(ObjectType::Value);
                 }
                 else {
-                    return Some(ObjectType::Node(current_layer.node_dict_get(corrected_id as usize)));
+                    return current_layer.node_dict_get(corrected_id as usize).map(ObjectType::Node);
                 }
             }
             else {

--- a/src/layer/layer.rs
+++ b/src/layer/layer.rs
@@ -21,7 +21,7 @@ pub trait Layer: Send+Sync {
     /// This also counts entries in the parent.
     fn predicate_count(&self) -> usize;
     /// Predicate dictionary get function
-    fn predicate_dict_get(&self, id: usize) -> String;
+    fn predicate_dict_get(&self, id: usize) -> Option<String>;
     /// Predicate dict length of this specific layer
     fn predicate_dict_len(&self) -> usize;
     /// Predicate dict id of current layer
@@ -29,7 +29,7 @@ pub trait Layer: Send+Sync {
     /// Node dict id of current layer
     fn node_dict_id(&self, subject: &str) -> Option<u64>;
     /// Node dictionary get function
-    fn node_dict_get(&self, id: usize) -> String;
+    fn node_dict_get(&self, id: usize) -> Option<String>;
     /// Node dict length of this specific layer
     fn node_dict_len(&self) -> usize;
     /// Value dict id of current layer
@@ -37,7 +37,7 @@ pub trait Layer: Send+Sync {
     /// Value dict length of this specific layer
     fn value_dict_len(&self) -> usize;
     /// Value dictionary get function
-    fn value_dict_get(&self, id: usize) -> String;
+    fn value_dict_get(&self, id: usize) -> Option<String>;
 
     /// The numerical id of a subject, or None if the subject cannot be found.
     fn subject_id(&self, subject: &str) -> Option<u64>;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -168,7 +168,7 @@ impl Layer for StoreLayer {
         self.layer.node_dict_len()
     }
 
-    fn node_dict_get(&self, id: usize) -> String {
+    fn node_dict_get(&self, id: usize) -> Option<String> {
         self.layer.node_dict_get(id)
     }
 
@@ -180,7 +180,7 @@ impl Layer for StoreLayer {
         self.layer.value_dict_id(value)
     }
 
-    fn value_dict_get(&self, id: usize) -> String {
+    fn value_dict_get(&self, id: usize) -> Option<String> {
         self.layer.value_dict_get(id)
     }
 
@@ -192,7 +192,7 @@ impl Layer for StoreLayer {
         self.layer.predicate_dict_len()
     }
 
-    fn predicate_dict_get(&self, id: usize) -> String {
+    fn predicate_dict_get(&self, id: usize) -> Option<String> {
         self.layer.predicate_dict_get(id)
     }
 

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -143,11 +143,11 @@ impl Layer for SyncStoreLayer {
         self.inner.value_dict_len()
     }
 
-    fn value_dict_get(&self, id: usize) -> String {
+    fn value_dict_get(&self, id: usize) -> Option<String> {
         self.inner.value_dict_get(id)
     }
 
-    fn node_dict_get(&self, id: usize) -> String {
+    fn node_dict_get(&self, id: usize) -> Option<String> {
         self.inner.node_dict_get(id)
     }
 
@@ -159,7 +159,7 @@ impl Layer for SyncStoreLayer {
         self.inner.predicate_dict_id(predicate)
     }
 
-    fn predicate_dict_get(&self, id: usize) -> String {
+    fn predicate_dict_get(&self, id: usize) -> Option<String> {
         self.inner.predicate_dict_get(id)
     }
 

--- a/src/structure/pfc.rs
+++ b/src/structure/pfc.rs
@@ -445,6 +445,13 @@ mod tests {
         assert_eq!(Some("aabbb".to_string()), p.get(1));
         assert_eq!(Some("ccccc".to_string()), p.get(2));
         assert_eq!(None, p.get(4));
+
+        let mut i = p.strings();
+
+        assert_eq!(Some("aaaaa".to_string()), i.next());
+        assert_eq!(Some("aabbb".to_string()), i.next());
+        assert_eq!(Some("ccccc".to_string()), i.next());
+        assert_eq!(None, i.next());
     }
 
     #[test]

--- a/src/structure/pfc.rs
+++ b/src/structure/pfc.rs
@@ -168,11 +168,12 @@ impl<M:AsRef<[u8]>+Clone> PfcBlock<M> {
         }
     }
 
-    pub fn get(&self, index: usize) -> String {
-        if index >= self.n_strings {
-            panic!("index too high");
+    pub fn get(&self, index: usize) -> Option<String> {
+        if index < self.n_strings {
+            self.strings().nth(index)
+        } else {
+            None
         }
-        self.strings().nth(index).unwrap()
     }
 
     pub fn len(&self) -> usize {
@@ -241,17 +242,21 @@ impl<M:AsRef<[u8]>+Clone> PfcDict<M> {
         self.n_strings as usize
     }
 
-    pub fn get(&self, ix: usize) -> String {
-        if ix as u64 >= self.n_strings {
-            panic!("index too high");
+    pub fn get(&self, ix: usize) -> Option<String> {
+        if (ix as u64) < self.n_strings {
+            let block_index = ix / BLOCK_SIZE;
+            let block_offset = if block_index == 0 {
+                0
+            } else {
+                self.block_offsets.entry(block_index - 1)
+            };
+            let block = PfcBlock::parse(&self.blocks.as_ref()[block_offset as usize..]).unwrap();
+
+            let index_in_block = ix % BLOCK_SIZE;
+            block.get(index_in_block)
+        } else {
+            None
         }
-
-        let block_index = ix / BLOCK_SIZE;
-        let block_offset = if block_index == 0 { 0 } else { self.block_offsets.entry(block_index-1) };
-        let block = PfcBlock::parse(&self.blocks.as_ref()[block_offset as usize..]).unwrap();
-
-        let index_in_block = ix % BLOCK_SIZE;
-        block.get(index_in_block)
     }
 
     pub fn id(&self, s: &str) -> Option<u64> {
@@ -436,9 +441,10 @@ mod tests {
 
         let p = PfcDict::parse(blocks.map().wait().unwrap(), offsets.map().wait().unwrap()).unwrap();
 
-        assert_eq!("aaaaa", p.get(0));
-        assert_eq!("aabbb", p.get(1));
-        assert_eq!("ccccc", p.get(2));
+        assert_eq!(Some("aaaaa".to_string()), p.get(0));
+        assert_eq!(Some("aabbb".to_string()), p.get(1));
+        assert_eq!(Some("ccccc".to_string()), p.get(2));
+        assert_eq!(None, p.get(4));
     }
 
     #[test]
@@ -465,11 +471,12 @@ mod tests {
 
         let p = PfcDict::parse(blocks.map().wait().unwrap(), offsets.map().wait().unwrap()).unwrap();
 
-        assert_eq!("aaaaa", p.get(0));
-        assert_eq!("aabbb", p.get(1));
-        assert_eq!("ccccc", p.get(2));
-        assert_eq!("eeee", p.get(8));
-        assert_eq!("great scott", p.get(9));
+        assert_eq!(Some("aaaaa".to_string()), p.get(0));
+        assert_eq!(Some("aabbb".to_string()), p.get(1));
+        assert_eq!(Some("ccccc".to_string()), p.get(2));
+        assert_eq!(Some("eeee".to_string()), p.get(8));
+        assert_eq!(Some("great scott".to_string()), p.get(9));
+        assert_eq!(None, p.get(10));
     }
 
     #[test]


### PR DESCRIPTION
This changes `PfcBlock::get` and `PfcList::get` to return `Option<String>` to avoid using `panic` for out-of-range index arguments.

The low-level change trickles up through `layer::base` and `layer::child`, but the logic there is also simplified by removing a duplicate range check.

Fixes #28