### PR TITLE
Lookup refactor

### DIFF
--- a/src/layer/layer.rs
+++ b/src/layer/layer.rs
@@ -1,6 +1,7 @@
 //! Common data structures and traits for all layer types.
 use std::hash::Hash;
 use std::collections::HashMap;
+use std::iter::Peekable;
 
 /// A layer containing dictionary entries and triples.
 ///
@@ -60,9 +61,22 @@ pub trait Layer: Send+Sync {
     /// `SubjectLookup`. Each such object stores a
     /// subject id, and knows how to retrieve any linked
     /// predicate-object pair.
-    fn subjects(&self) -> Box<dyn Iterator<Item=Box<dyn SubjectLookup>>>;
-    /// Subjects for current layer
-    fn subjects_current_layer(&self, parent: Box<dyn Iterator<Item=Box<dyn SubjectLookup>>>) -> Box<dyn Iterator<Item=Box<dyn SubjectLookup>>>;
+    fn subjects(&self) -> Box<dyn Iterator<Item=Box<dyn SubjectLookup>>> {
+        let mut layers = Vec::new();
+        layers.push((self.subject_additions().peekable(), self.subject_removals().peekable()));
+        let mut cur = self.parent();
+
+        while cur.is_some() {
+            layers.push((cur.unwrap().subject_additions().peekable(),cur.unwrap().subject_removals().peekable()));
+            cur = cur.unwrap().parent();
+        }
+
+        let it = GenericSubjectIterator {
+            layers
+        };
+
+        Box::new(it.map(|s| Box::new(s) as Box<dyn SubjectLookup>))
+    }
 
     /// Returns an iterator over all triple data added by this layer.
     ///
@@ -70,7 +84,7 @@ pub trait Layer: Send+Sync {
     /// `SubjectLookup`. Each such object stores a
     /// subject id, and knows how to retrieve any linked
     /// predicate-object pair.
-    fn subject_additions(&self) -> Box<dyn Iterator<Item=Box<dyn SubjectLookup>>>;
+    fn subject_additions(&self) -> Box<dyn Iterator<Item=Box<dyn LayerSubjectLookup>>>;
 
     /// Returns an iterator over all triple data removed by this layer.
     ///
@@ -78,7 +92,7 @@ pub trait Layer: Send+Sync {
     /// `SubjectLookup`. Each such object stores a
     /// subject id, and knows how to retrieve any linked
     /// predicate-object pair.
-    fn subject_removals(&self) -> Box<dyn Iterator<Item=Box<dyn SubjectLookup>>>;
+    fn subject_removals(&self) -> Box<dyn Iterator<Item=Box<dyn LayerSubjectLookup>>>;
 
     /// Returns a `SubjectLookup` object for the given subject, or None if it cannot be constructed.
     ///
@@ -88,10 +102,27 @@ pub trait Layer: Send+Sync {
     /// registered an addition involving this subject. However, later
     /// layers may have then removed every triple involving this
     /// subject.
-    fn lookup_subject(&self, subject: u64) -> Option<Box<dyn SubjectLookup>>;
+    fn lookup_subject(&self, subject: u64) -> Option<Box<dyn SubjectLookup>> {
+        let mut lookups = Vec::new();
+        lookups.push((self.lookup_subject_addition(subject), self.lookup_subject_removal(subject)));
 
-    /// lookup_subject for only current layer
-    fn lookup_subject_current_layer(&self, subject: u64, parent: Option<Box<dyn SubjectLookup>>) -> Option<Box<dyn SubjectLookup>>;
+        let mut cur = self.parent();
+        while cur.is_some() {
+            lookups.push((cur.unwrap().lookup_subject_addition(subject),
+                          cur.unwrap().lookup_subject_removal(subject)));
+            cur = cur.unwrap().parent();
+        }
+
+        if lookups.iter().any(|(pos, _neg)| pos.is_some()) {
+            Some(Box::new(GenericSubjectLookup {
+                subject: subject,
+                lookups: lookups
+            }) as Box<dyn SubjectLookup>)
+        }
+        else {
+            None
+        }
+    }
 
     /// Returns a `SubjectLookup` object for the given subject, or None if it cannot be constructed.
     ///
@@ -102,32 +133,47 @@ pub trait Layer: Send+Sync {
     /// layers may have then removed every triple involving this
     /// subject.
 
-    fn lookup_subject_addition(&self, subject: u64) -> Option<Box<dyn SubjectLookup>>;
+    fn lookup_subject_addition(&self, subject: u64) -> Option<Box<dyn LayerSubjectLookup>>;
     /// Returns a `SubjectLookup` object for the given subject, or None if it cannot be constructed.
     ///
     /// This will only lookup in the current layer.
-    fn lookup_subject_removal(&self, subject: u64) -> Option<Box<dyn SubjectLookup>>;
+    fn lookup_subject_removal(&self, subject: u64) -> Option<Box<dyn LayerSubjectLookup>>;
 
     /// Returns an iterator over all objects known to this layer.
     ///
     /// Objects are returned as an `ObjectLookup`, an object that can
     /// then be queried for subject-predicate pairs pointing to that
     /// object.
-    fn objects(&self) -> Box<dyn Iterator<Item=Box<dyn ObjectLookup>>>;
+    fn objects(&self) -> Box<dyn Iterator<Item=Box<dyn ObjectLookup>>> {
+        let mut layers = Vec::new();
+        layers.push((self.object_additions().peekable(), self.object_removals().peekable()));
+        let mut cur = self.parent();
+
+        while cur.is_some() {
+            layers.push((cur.unwrap().object_additions().peekable(),cur.unwrap().object_removals().peekable()));
+            cur = cur.unwrap().parent();
+        }
+
+        let it = GenericObjectIterator {
+            layers
+        };
+
+        Box::new(it.map(|s| Box::new(s) as Box<dyn ObjectLookup>))
+    }
 
     /// Returns an iterator over all objects added by this layer.
     ///
     /// Objects are returned as an `ObjectLookup`, an object that can
     /// then be queried for subject-predicate pairs pointing to that
     /// object.
-    fn object_additions(&self) -> Box<dyn Iterator<Item=Box<dyn ObjectLookup>>>;
+    fn object_additions(&self) -> Box<dyn Iterator<Item=Box<dyn LayerObjectLookup>>>;
 
     /// Returns an iterator over all objects removed by this layer.
     ///
     /// Objects are returned as an `ObjectLookup`, an object that can
     /// then be queried for subject-predicate pairs pointing to that
     /// object.
-    fn object_removals(&self) -> Box<dyn Iterator<Item=Box<dyn ObjectLookup>>>;
+    fn object_removals(&self) -> Box<dyn Iterator<Item=Box<dyn LayerObjectLookup>>>;
 
     /// Returns an `ObjectLookup` for the given object, or None if it could not be constructed.
     ///
@@ -138,19 +184,37 @@ pub trait Layer: Send+Sync {
     /// registered an addition involving this object. However, later
     /// layers may have then removed every triple involving this
     /// object.
-    fn lookup_object(&self, object: u64) -> Option<Box<dyn ObjectLookup>>;
-    /// Only lookup object for current layer
-    fn lookup_object_current_layer(&self, object: u64, parent: Option<Box<dyn ObjectLookup>>) -> Option<Box<dyn ObjectLookup>>;
+    fn lookup_object(&self, object: u64) -> Option<Box<dyn ObjectLookup>> {
+       let mut lookups = Vec::new();
+        lookups.push((self.lookup_object_addition(object), self.lookup_object_removal(object)));
+
+        let mut cur = self.parent();
+        while cur.is_some() {
+            lookups.push((cur.unwrap().lookup_object_addition(object),
+                          cur.unwrap().lookup_object_removal(object)));
+            cur = cur.unwrap().parent();
+        }
+
+        if lookups.iter().any(|(pos, _neg)|pos.is_some()) {
+            Some(Box::new(GenericObjectLookup {
+                object,
+                lookups
+            }))
+        }
+        else {
+            None
+        }
+    }
 
     /// Returns an `ObjectLookup` for the given object, or None if it could not be constructed.
     ///
     /// This will only lookup in the current layer.
-    fn lookup_object_addition(&self, object: u64) -> Option<Box<dyn ObjectLookup>>;
+    fn lookup_object_addition(&self, object: u64) -> Option<Box<dyn LayerObjectLookup>>;
 
     /// Returns an `ObjectLookup` for the given object, or None if it could not be constructed.
     ///
     /// This will only lookup in the current layer.
-    fn lookup_object_removal(&self, object: u64) -> Option<Box<dyn ObjectLookup>>;
+    fn lookup_object_removal(&self, object: u64) -> Option<Box<dyn LayerObjectLookup>>;
 
     /// Returns a `PredicateLookup` for the given predicate, or None if it could not be constructed.
     ///
@@ -160,19 +224,37 @@ pub trait Layer: Send+Sync {
     /// has registered an addition involving this predicate. However,
     /// later layers may have then removed every triple involving this
     /// predicate.
-    fn lookup_predicate(&self, predicate: u64) -> Option<Box<dyn PredicateLookup>>;
-    /// Only lookup predicate for current layer
-    fn lookup_predicate_current_layer(&self, predicate: u64, parent: Option<Box<dyn PredicateLookup>>) -> Option<Box<dyn PredicateLookup>>;
+    fn lookup_predicate(&self, predicate: u64) -> Option<Box<dyn PredicateLookup>> {
+        let mut lookups = Vec::new();
+        lookups.push((self.lookup_predicate_addition(predicate), self.lookup_predicate_removal(predicate)));
+
+        let mut cur = self.parent();
+        while cur.is_some() {
+            lookups.push((cur.unwrap().lookup_predicate_addition(predicate),
+                          cur.unwrap().lookup_predicate_removal(predicate)));
+            cur = cur.unwrap().parent();
+        }
+
+        if lookups.iter().any(|(pos, _neg)| pos.is_some()) {
+            Some(Box::new(GenericPredicateLookup {
+                predicate: predicate,
+                lookups: lookups
+            }) as Box<dyn PredicateLookup>)
+        }
+        else {
+            None
+        }
+    }
 
     /// Returns a `PredicateLookup` for the given predicate, or None if it could not be constructed.
     ///
     /// This will only lookup in the current layer.
-    fn lookup_predicate_addition(&self, predicate: u64) -> Option<Box<dyn PredicateLookup>>;
+    fn lookup_predicate_addition(&self, predicate: u64) -> Option<Box<dyn LayerPredicateLookup>>;
 
     /// Returns a `PredicateLookup` for the given predicate, or None if it could not be constructed.
     ///
     /// This will only lookup in the current layer.
-    fn lookup_predicate_removal(&self, predicate: u64) -> Option<Box<dyn PredicateLookup>>;
+    fn lookup_predicate_removal(&self, predicate: u64) -> Option<Box<dyn LayerPredicateLookup>>;
 
     /// Create a struct with all the counts
     fn all_counts(&self) -> LayerCounts {
@@ -194,12 +276,12 @@ pub trait Layer: Send+Sync {
         Box::new((1..=self.predicate_count()).map(move |p|cloned.lookup_predicate(p as u64)).flatten())
     }
 
-    fn predicate_additions(&self) -> Box<dyn Iterator<Item=Box<dyn PredicateLookup>>> {
+    fn predicate_additions(&self) -> Box<dyn Iterator<Item=Box<dyn LayerPredicateLookup>>> {
         let cloned = self.clone_boxed();
         Box::new((1..=self.predicate_count()).map(move |p|cloned.lookup_predicate_addition(p as u64)).flatten())
     }
 
-    fn predicate_removals(&self) -> Box<dyn Iterator<Item=Box<dyn PredicateLookup>>> {
+    fn predicate_removals(&self) -> Box<dyn Iterator<Item=Box<dyn LayerPredicateLookup>>> {
         let cloned = self.clone_boxed();
         Box::new((1..=self.predicate_count()).map(move |p|cloned.lookup_predicate_removal(p as u64)).flatten())
     }
@@ -306,6 +388,108 @@ pub enum LayerType {
     Child
 }
 
+struct GenericSubjectIterator {
+    layers: Vec<(Peekable<Box<dyn Iterator<Item=Box<dyn LayerSubjectLookup>>>>,Peekable<Box<dyn Iterator<Item=Box<dyn LayerSubjectLookup>>>>)>
+}
+
+impl Iterator for GenericSubjectIterator {
+    type Item = GenericSubjectLookup;
+
+    fn next(&mut self) -> Option<GenericSubjectLookup> {
+        // find the very lowest subject
+        let mut min = None;
+        for (pos, _neg) in self.layers.iter_mut() {
+            let pos_subject = pos.peek().map(|lookup|lookup.subject());
+
+            if pos_subject.is_some() && (min.is_none() || pos_subject < min) {
+                min = pos_subject;
+            }
+        }
+
+        if min.is_none() {
+            // there are no more positives left, so we're done
+            return None;
+        }
+
+        // now collect a vec of lookups
+        let min = min.unwrap();
+        let lookups = self.layers.iter_mut()
+            .map(|(pos, neg)| {
+                let pos_subject = match pos.peek().map(|lookup|min == lookup.subject()).unwrap_or(false) {
+                    true => pos.next(),
+                    false => None
+                };
+                let neg_subject = match neg.peek().map(|lookup|min == lookup.subject()).unwrap_or(false) {
+                    true => neg.next(),
+                    false => None
+                };
+
+                (pos_subject, neg_subject)
+            }).collect();
+
+        Some(GenericSubjectLookup {
+            subject: min,
+            lookups: lookups
+        })
+    }
+}
+
+/// A trait that caches a lookup in a layer by subject, but only for that layer and not its parents.
+///
+/// This is returned by `Layer::subjects` and
+/// `Layer::lookup_subject`. It stores slices of
+/// the relevant data structures to allow quick retrieval of
+/// predicate-object pairs when one already knows the subject.
+pub trait LayerSubjectLookup {
+    /// The subject that this lookup is based on
+    fn subject(&self) -> u64;
+    /// Returns an iterator over predicate lookups
+    fn predicates(&self) -> Box<dyn Iterator<Item=Box<dyn LayerSubjectPredicateLookup>>>;
+    /// Returns a predicate lookup for the given predicate, or None if no such lookup could be constructed
+    fn lookup_predicate(&self, predicate: u64) -> Option<Box<dyn LayerSubjectPredicateLookup>>;
+    /// Returns an iterator over all triples that can be found by this lookup
+    fn triples(&self) -> Box<dyn Iterator<Item=IdTriple>> {
+        Box::new(self.predicates().map(|p|p.triples()).flatten())
+    }
+}
+
+/// a trait that caches a lookup in a layer by subject and predicate, but only for that layer and not its parents.
+///
+/// This is returned by `SubjectLookup::predicates`
+/// and `SubjectLookup::lookup_predicate`. It
+/// stores slices of the relevant data structures to allow quick
+/// retrieval of objects when one already knows the subject and
+/// predicate.
+pub trait LayerSubjectPredicateLookup {
+    /// The subject that this lookup is based on.
+    fn subject(&self) -> u64;
+    /// The predicate that this lookup is based on.
+    fn predicate(&self) -> u64;
+
+    /// Returns an iterator over all objects that can be found by this lookup.
+    fn objects(&self) -> Box<dyn Iterator<Item=u64>>;
+
+    /// Returns true if the given object exists, and false otherwise.
+    fn has_object(&self, object: u64) -> bool;
+
+    /// Returns an iterator over all triples that can be found by this lookup.
+    fn triples(&self) -> Box<dyn Iterator<Item=IdTriple>> {
+        let subject = self.subject();
+        let predicate = self.predicate();
+        Box::new(self.objects().map(move |o| IdTriple::new(subject, predicate, o)))
+    }
+
+    /// Returns a triple for the given object, or None if it doesn't exist.
+    fn triple(&self, object: u64) -> Option<IdTriple> {
+        if self.has_object(object) {
+            Some(IdTriple::new(self.subject(), self.predicate(), object))
+        }
+        else {
+            None
+        }
+    }
+}
+
 /// A trait that caches a lookup in a layer by subject.
 ///
 /// This is returned by `Layer::subjects` and
@@ -315,10 +499,6 @@ pub enum LayerType {
 pub trait SubjectLookup {
     /// The subject that this lookup is based on
     fn subject(&self) -> u64;
-    /// Get the parent
-    fn parent(&self) -> Option<&dyn SubjectLookup>;
-    /// Returns predicates for current layer
-    fn predicates_current_layer(&self, parent: Option<Box<dyn Iterator<Item=Box<dyn SubjectPredicateLookup>>>>) -> Box<dyn Iterator<Item=Box<dyn SubjectPredicateLookup>>>;
     /// Returns an iterator over predicate lookups
     fn predicates(&self) -> Box<dyn Iterator<Item=Box<dyn SubjectPredicateLookup>>>;
     /// Returns a predicate lookup for the given predicate, or None if no such lookup could be constructed
@@ -329,10 +509,105 @@ pub trait SubjectLookup {
     /// lookup to be constructable, but if subsequent layers deleted
     /// all these triples, none will be retrievable.
     fn lookup_predicate(&self, predicate: u64) -> Option<Box<dyn SubjectPredicateLookup>>;
-    fn lookup_predicate_current(&self, predicate: u64, parent: Option<Box<dyn SubjectPredicateLookup>>) -> Option<Box<dyn SubjectPredicateLookup>>;
     /// Returns an iterator over all triples that can be found by this lookup
     fn triples(&self) -> Box<dyn Iterator<Item=IdTriple>> {
         Box::new(self.predicates().map(|p|p.triples()).flatten())
+    }
+}
+
+/// A SubjectLookup that is implemented in terms of addition and removal lookups
+struct GenericSubjectLookup {
+    subject: u64,
+    lookups: Vec<(Option<Box<dyn LayerSubjectLookup>>,Option<Box<dyn LayerSubjectLookup>>)>
+}
+
+impl SubjectLookup for GenericSubjectLookup {
+    fn subject(&self) -> u64 {
+        self.subject
+    }
+
+    fn predicates(&self) -> Box<dyn Iterator<Item=Box<dyn SubjectPredicateLookup>>> {
+        let layers = self.lookups.iter()
+            .map(|(pos, neg)| (pos.as_ref()
+                               .map(|p|Box::new(p.predicates()) as Box<dyn Iterator<Item=Box<dyn LayerSubjectPredicateLookup>>>)
+                               .unwrap_or(Box::new(std::iter::empty()))
+                               .peekable(),
+                               neg.as_ref()
+                               .map(|n|Box::new(n.predicates()) as Box<dyn Iterator<Item=Box<dyn LayerSubjectPredicateLookup>>>)
+                               .unwrap_or(Box::new(std::iter::empty()))
+                               .peekable()))
+            .collect();
+
+        Box::new(GenericSubjectPredicateIterator {
+            subject: self.subject,
+            layers: layers
+        }.map(|lookup|Box::new(lookup) as Box<dyn SubjectPredicateLookup>))
+    }
+
+    fn lookup_predicate(&self, predicate: u64) -> Option<Box<dyn SubjectPredicateLookup>> {
+        let lookups: Vec<_> = self.lookups.iter()
+            .map(|(pos, neg)| (pos.as_ref().and_then(|p|p.lookup_predicate(predicate)),
+                               neg.as_ref().and_then(|n|n.lookup_predicate(predicate))))
+            .collect();
+
+        if lookups.iter().find(|(pos, _neg)| pos.is_some()).is_some() {
+            Some(Box::new(GenericSubjectPredicateLookup {
+                subject: self.subject,
+                predicate: predicate,
+                lookups: lookups
+            }))
+        }
+        else {
+            None
+        }
+    }
+}
+
+struct GenericSubjectPredicateIterator {
+    subject: u64,
+    layers: Vec<(Peekable<Box<dyn Iterator<Item=Box<dyn LayerSubjectPredicateLookup>>>>,Peekable<Box<dyn Iterator<Item=Box<dyn LayerSubjectPredicateLookup>>>>)>
+}
+
+impl Iterator for GenericSubjectPredicateIterator {
+    type Item = GenericSubjectPredicateLookup;
+
+    fn next(&mut self) -> Option<GenericSubjectPredicateLookup> {
+        // find the very lowest predicate
+        let mut min = None;
+        for (pos, _neg) in self.layers.iter_mut() {
+            let pos_predicate = pos.peek().map(|lookup|lookup.predicate());
+
+            if pos_predicate.is_some() && (min.is_none() || pos_predicate < min) {
+                min = pos_predicate;
+            }
+        }
+
+        if min.is_none() {
+            // there are no more positives left, so we're done
+            return None;
+        }
+
+        // now collect a vec of lookups
+        let min = min.unwrap();
+        let lookups = self.layers.iter_mut()
+            .map(|(pos, neg)| {
+                let pos_predicate = match pos.peek().map(|lookup|min == lookup.predicate()).unwrap_or(false) {
+                    true => pos.next(),
+                    false => None
+                };
+                let neg_predicate = match neg.peek().map(|lookup|min == lookup.predicate()).unwrap_or(false) {
+                    true => neg.next(),
+                    false => None
+                };
+
+                (pos_predicate, neg_predicate)
+            }).collect();
+
+        Some(GenericSubjectPredicateLookup {
+            subject: self.subject,
+            predicate: min,
+            lookups: lookups
+        })
     }
 }
 
@@ -361,9 +636,6 @@ pub trait SubjectPredicateLookup {
     /// Returns true if the given object exists, and false otherwise.
     fn has_object(&self, object: u64) -> bool;
 
-    /// Returns the parent lookup, or None if it doesn't exist.
-    fn parent(&self) -> Option<&dyn SubjectPredicateLookup>;
-
     /// Returns an iterator over all triples that can be found by this lookup.
     fn triples(&self) -> Box<dyn Iterator<Item=IdTriple>> {
         let subject = self.subject();
@@ -379,6 +651,144 @@ pub trait SubjectPredicateLookup {
         else {
             None
         }
+    }
+}
+
+struct GenericSubjectPredicateLookup {
+    subject: u64,
+    predicate: u64,
+    lookups: Vec<(Option<Box<dyn LayerSubjectPredicateLookup>>, Option<Box<dyn LayerSubjectPredicateLookup>>)>
+}
+
+impl SubjectPredicateLookup for GenericSubjectPredicateLookup {
+    fn subject(&self) -> u64 {
+        self.subject
+    }
+
+    fn predicate(&self) -> u64 {
+        self.predicate
+    }
+
+    
+    fn objects(&self) -> Box<dyn Iterator<Item=u64>> {
+        let layers = self.lookups.iter()
+            .map(|(pos, neg)| (pos.as_ref()
+                               .map(|p|Box::new(p.objects()) as Box<dyn Iterator<Item=u64>>)
+                               .unwrap_or(Box::new(std::iter::empty()))
+                               .peekable(),
+                               neg.as_ref()
+                               .map(|n|Box::new(n.objects()) as Box<dyn Iterator<Item=u64>>)
+                               .unwrap_or(Box::new(std::iter::empty()))
+                               .peekable()))
+            .collect();
+
+        Box::new(GenericSubjectPredicateObjectIterator {
+            layers,
+        })
+    }
+
+    fn has_pos_object_in_lookup(&self, object: u64) -> bool {
+        self.lookups.first()
+            .and_then(|last| last.0.as_ref())
+            .map(|pos| pos.has_object(object))
+            .unwrap_or(false)
+    }
+
+    fn has_neg_object_in_lookup(&self, object: u64) -> bool {
+        self.lookups.first()
+            .and_then(|last| last.1.as_ref())
+            .map(|pos| pos.has_object(object))
+            .unwrap_or(false)
+    }
+
+    fn has_object(&self, object: u64) -> bool {
+        for (pos, neg) in self.lookups.iter() {
+            if pos.as_ref().map(|p|p.has_object(object)).unwrap_or(false) {
+                return true;
+            }
+            if neg.as_ref().map(|p|p.has_object(object)).unwrap_or(false) {
+                return false;
+            }
+        }
+
+        false
+    }
+}
+
+struct GenericSubjectPredicateObjectIterator {
+    layers: Vec<(Peekable<Box<dyn Iterator<Item=u64>>>,Peekable<Box<dyn Iterator<Item=u64>>>)>,
+}
+
+impl Iterator for GenericSubjectPredicateObjectIterator {
+    type Item = u64;
+
+    fn next(&mut self) -> Option<u64> {
+        // what is the lowest number to talk about now?
+        let mut min = None;
+        for (pos, neg) in self.layers.iter_mut().rev() {
+            let pos_object = pos.peek().map(|o|*o);
+            let neg_object = neg.peek().map(|o|*o);
+            if pos_object.is_some() && (min.is_none() || pos_object < min) {
+                min = pos_object;
+            }
+            else if neg_object == min {
+                min = None;
+            }
+        }
+
+        // advance all iterators until they're either exhausted or beyond the min we found
+        // if min is None, we need to exhaust everything
+        for (pos, neg) in self.layers.iter_mut() {
+            while pos.peek().is_some() && (min.is_none() || pos.peek().map(|o|*o).unwrap() <= min.unwrap()) {
+                pos.next().unwrap();
+            }
+            while neg.peek().is_some() && (min.is_none() || neg.peek().map(|o|*o).unwrap() <= min.unwrap()) {
+                neg.next().unwrap();
+            }
+        }
+
+        min
+    }
+}
+
+/// a trait that caches a lookup by object in a single layer's addition or removals.
+pub trait LayerObjectLookup {
+    /// The object that this lookup is based on.
+    fn object(&self) -> u64;
+
+    /// Returns an iterator over the subject-predicate pairs pointing at this object.
+    fn subject_predicate_pairs(&self) -> Box<dyn Iterator<Item=(u64, u64)>>;
+
+    /// Returns true if the object this lookup is for is connected to the given subject and predicater.
+    fn has_subject_predicate_pair(&self, subject: u64, predicate: u64) -> bool {
+        for (s, p) in self.subject_predicate_pairs() {
+            if s == subject && p == predicate {
+                return true;
+            }
+            if s > subject || (s == subject && p > predicate) {
+                // we went past our search, so it's not going to appear anymore
+                return false;
+            }
+        }
+
+        false
+    }
+
+    /// Returns the triple consisting of the given subject and predicate, and the object this lookup is for, if it exists. None is returned otherwise.
+    fn triple(&self, subject: u64, predicate: u64) -> Option<IdTriple> {
+        if self.has_subject_predicate_pair(subject, predicate) {
+            Some(IdTriple::new(subject, predicate, self.object()))
+        }
+        else {
+            None
+        }
+    }
+
+    /// Returns an iterator over all triples with the object of this lookup.
+    fn triples(&self) -> Box<dyn Iterator<Item=IdTriple>> {
+        let object = self.object();
+        Box::new(self.subject_predicate_pairs()
+                 .map(move |(s,p)| IdTriple::new(s,p,object)))
     }
 }
 
@@ -426,6 +836,128 @@ pub trait ObjectLookup {
     }
 }
 
+struct GenericObjectIterator {
+    layers: Vec<(Peekable<Box<dyn Iterator<Item=Box<dyn LayerObjectLookup>>>>,Peekable<Box<dyn Iterator<Item=Box<dyn LayerObjectLookup>>>>)>
+}
+
+impl Iterator for GenericObjectIterator {
+    type Item = GenericObjectLookup;
+
+    fn next(&mut self) -> Option<GenericObjectLookup> {
+        let mut min = None;
+        for (pos, _neg) in self.layers.iter_mut() {
+            let pos_object = pos.peek().map(|lookup|lookup.object());
+
+            if pos_object.is_some() && (min.is_none() || pos_object < min) {
+                min = pos_object;
+            }
+        }
+
+        if min.is_none() {
+            // there are no more positives left, so we're done
+            return None;
+        }
+
+        // now collect a vec of lookups
+        let min = min.unwrap();
+        let lookups = self.layers.iter_mut()
+            .map(|(pos, neg)| {
+                let pos_object = match pos.peek().map(|lookup|min == lookup.object()).unwrap_or(false) {
+                    true => pos.next(),
+                    false => None
+                };
+                let neg_object = match neg.peek().map(|lookup|min == lookup.object()).unwrap_or(false) {
+                    true => neg.next(),
+                    false => None
+                };
+
+                (pos_object, neg_object)
+            }).collect();
+
+        Some(GenericObjectLookup {
+            object: min,
+            lookups: lookups
+        })
+    }
+}
+
+struct GenericObjectLookup {
+    object: u64,
+    lookups: Vec<(Option<Box<dyn LayerObjectLookup>>,Option<Box<dyn LayerObjectLookup>>)>
+}
+
+impl ObjectLookup for GenericObjectLookup {
+    fn object(&self) -> u64 {
+        self.object
+    }
+
+    fn subject_predicate_pairs(&self) -> Box<dyn Iterator<Item=(u64, u64)>> {
+        let layers: Vec<_> = self.lookups.iter()
+            .map(|(pos, neg)| (pos.as_ref().map(|p|p.subject_predicate_pairs())
+                               .unwrap_or(Box::new(std::iter::empty()))
+                               .peekable(),
+                               neg.as_ref().map(|p|p.subject_predicate_pairs())
+                               .unwrap_or(Box::new(std::iter::empty()))
+                               .peekable()))
+            .collect();
+
+        Box::new(ObjectSubjectPredicatePairIterator {
+            layers
+        })
+    }
+
+    fn parent(&self) -> Option<&dyn ObjectLookup> {
+        unimplemented!();
+    }
+}
+
+struct ObjectSubjectPredicatePairIterator {
+    layers: Vec<(Peekable<Box<dyn Iterator<Item=(u64,u64)>>>,Peekable<Box<dyn Iterator<Item=(u64,u64)>>>)>
+}
+
+impl Iterator for ObjectSubjectPredicatePairIterator {
+    type Item = (u64,u64);
+
+    fn next(&mut self) -> Option<(u64,u64)> {
+        let mut min = None;
+        for (pos, neg) in self.layers.iter_mut().rev() {
+            let pos_subject = pos.peek().map(|s|*s);
+            let neg_subject = neg.peek().map(|s|*s);
+            if pos_subject.is_some() && (min.is_none() || pos_subject < min) {
+                min = pos_subject;
+            }
+            else if neg_subject == min {
+                min = None;
+            }
+        }
+
+        // advance all iterators until they're either exhausted or beyond the min we found
+        // if min is None, we need to exhaust everything
+        for (pos, neg) in self.layers.iter_mut() {
+            while pos.peek().is_some() && (min.is_none() || pos.peek().map(|s|*s).unwrap() <= min.unwrap()) {
+                pos.next().unwrap();
+            }
+            while neg.peek().is_some() && (min.is_none() || neg.peek().map(|s|*s).unwrap() <= min.unwrap()) {
+                neg.next().unwrap();
+            }
+        }
+
+        min
+    }
+}
+
+pub trait LayerPredicateLookup {
+    fn predicate(&self) -> u64;
+    fn subject_predicate_pairs(&self) -> Box<dyn Iterator<Item=Box<dyn LayerSubjectPredicateLookup>>>;
+
+    /// Returns an iterator over all triples with the object of this lookup.
+    fn triples(&self) -> Box<dyn Iterator<Item=IdTriple>> {
+        Box::new(self.subject_predicate_pairs()
+                 .map(move |sp| sp.triples())
+                 .flatten())
+    }
+}
+
 /// A trait that caches a lookup in a layer by predicate.
 pub trait PredicateLookup {
     fn predicate(&self) -> u64;
@@ -436,6 +968,77 @@ pub trait PredicateLookup {
         Box::new(self.subject_predicate_pairs()
                  .map(move |sp| sp.triples())
                  .flatten())
+    }
+}
+
+struct GenericPredicateLookup {
+    predicate: u64,
+    lookups: Vec<(Option<Box<dyn LayerPredicateLookup>>, Option<Box<dyn LayerPredicateLookup>>)>
+}
+
+impl PredicateLookup for GenericPredicateLookup {
+    fn predicate(&self) -> u64 {
+        self.predicate
+    }
+
+    fn subject_predicate_pairs(&self) -> Box<dyn Iterator<Item=Box<dyn SubjectPredicateLookup>>> {
+        let layers: Vec<_> = self.lookups.iter()
+            .map(|(pos, neg)|(pos.as_ref().map(|p|p.subject_predicate_pairs())
+                              .unwrap_or(Box::new(std::iter::empty()))
+                              .peekable(),
+                              neg.as_ref().map(|n|n.subject_predicate_pairs())
+                              .unwrap_or(Box::new(std::iter::empty()))
+                              .peekable()))
+            .collect();
+
+        Box::new(GenericSubjectPredicatePairIterator {
+            predicate: self.predicate,
+            layers: layers
+        }.map(|l| Box::new(l) as Box<dyn SubjectPredicateLookup>))
+    }
+}
+
+struct GenericSubjectPredicatePairIterator {
+    predicate: u64,
+    layers: Vec<(Peekable<Box<dyn Iterator<Item=Box<dyn LayerSubjectPredicateLookup>>>>,Peekable<Box<dyn Iterator<Item=Box<dyn LayerSubjectPredicateLookup>>>>)>
+}
+
+impl Iterator for GenericSubjectPredicatePairIterator {
+    type Item = GenericSubjectPredicateLookup;
+
+    fn next(&mut self) -> Option<GenericSubjectPredicateLookup> {
+        let mut min = None;
+        for (pos, _neg) in self.layers.iter_mut() {
+            let subject = pos.peek().map(|l|l.subject());
+            if subject.is_some() && (min.is_none() || subject < min) {
+                min = subject;
+            }
+        }
+
+        if min.is_none() {
+            return None;
+        }
+        
+        let mut lookups = Vec::with_capacity(self.layers.len());
+
+        for (pos, neg) in self.layers.iter_mut() {
+            let mut pos_lookup = None;
+            if pos.peek().map(|l|l.subject()) == min {
+                pos_lookup = pos.next();
+            }
+            let mut neg_lookup = None;
+            if neg.peek().map(|l|l.subject()) == min {
+                neg_lookup = neg.next();
+            }
+
+            lookups.push((pos_lookup, neg_lookup));
+        }
+
+        Some(GenericSubjectPredicateLookup {
+            subject: min.unwrap(),
+            predicate: self.predicate,
+            lookups: lookups
+        })
     }
 }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -13,7 +13,7 @@ use futures_locks::RwLock;
 use crate::storage::{LabelStore, LayerStore, CachedLayerStore, LockingHashMapLayerCache};
 use crate::storage::memory::{MemoryLabelStore, MemoryLayerStore};
 use crate::storage::directory::{DirectoryLabelStore, DirectoryLayerStore};
-use crate::layer::{Layer,LayerBuilder,ObjectType,StringTriple,IdTriple,SubjectLookup,ObjectLookup, PredicateLookup};
+use crate::layer::{Layer,LayerBuilder,ObjectType,StringTriple,IdTriple,LayerSubjectLookup,LayerObjectLookup,LayerPredicateLookup};
 
 use std::io;
 
@@ -228,79 +228,43 @@ impl Layer for StoreLayer {
         self.layer.id_object(id)
     }
 
-    fn subjects_current_layer(&self, parent: Box<dyn Iterator<Item=Box<dyn SubjectLookup>>>) -> Box<dyn Iterator<Item=Box<dyn SubjectLookup>>> {
-        self.layer.subjects_current_layer(parent)
-    }
-
-    fn subjects(&self) -> Box<dyn Iterator<Item=Box<dyn SubjectLookup>>> {
-        self.layer.subjects()
-    }
-
-    fn subject_additions(&self) -> Box<dyn Iterator<Item=Box<dyn SubjectLookup>>> {
+    fn subject_additions(&self) -> Box<dyn Iterator<Item=Box<dyn LayerSubjectLookup>>> {
         self.layer.subject_additions()
     }
 
-    fn subject_removals(&self) -> Box<dyn Iterator<Item=Box<dyn SubjectLookup>>> {
+    fn subject_removals(&self) -> Box<dyn Iterator<Item=Box<dyn LayerSubjectLookup>>> {
         self.layer.subject_removals()
     }
 
-    fn lookup_subject(&self, subject: u64) -> Option<Box<dyn SubjectLookup>> {
-        self.layer.lookup_subject(subject)
-    }
-
-    fn lookup_subject_addition(&self, subject: u64) -> Option<Box<dyn SubjectLookup>> {
+    fn lookup_subject_addition(&self, subject: u64) -> Option<Box<dyn LayerSubjectLookup>> {
         self.layer.lookup_subject_addition(subject)
     }
 
-    fn lookup_subject_removal(&self, subject: u64) -> Option<Box<dyn SubjectLookup>> {
+    fn lookup_subject_removal(&self, subject: u64) -> Option<Box<dyn LayerSubjectLookup>> {
         self.layer.lookup_subject_removal(subject)
     }
 
-    fn lookup_subject_current_layer(&self, subject: u64, parent: Option<Box<dyn SubjectLookup>>) -> Option<Box<dyn SubjectLookup>> {
-        self.layer.lookup_subject_current_layer(subject, parent)
-    }
-
-    fn lookup_predicate_current_layer(&self, predicate: u64, parent: Option<Box<dyn PredicateLookup>>) -> Option<Box<dyn PredicateLookup>> {
-        self.layer.lookup_predicate_current_layer(predicate, parent)
-    }
-
-    fn objects(&self) -> Box<dyn Iterator<Item=Box<dyn ObjectLookup>>> {
-        self.layer.objects()
-    }
-
-    fn object_additions(&self) -> Box<dyn Iterator<Item=Box<dyn ObjectLookup>>> {
+    fn object_additions(&self) -> Box<dyn Iterator<Item=Box<dyn LayerObjectLookup>>> {
         self.layer.object_additions()
     }
 
-    fn object_removals(&self) -> Box<dyn Iterator<Item=Box<dyn ObjectLookup>>> {
+    fn object_removals(&self) -> Box<dyn Iterator<Item=Box<dyn LayerObjectLookup>>> {
         self.layer.object_removals()
     }
 
-    fn lookup_object_current_layer(&self, object: u64, parent: Option<Box<dyn ObjectLookup>>) -> Option<Box<dyn ObjectLookup>> {
-        self.layer.lookup_object_current_layer(object, parent)
-    }
-
-    fn lookup_object(&self, object: u64) -> Option<Box<dyn ObjectLookup>> {
-        self.layer.lookup_object(object)
-    }
-
-    fn lookup_object_addition(&self, object: u64) -> Option<Box<dyn ObjectLookup>> {
+    fn lookup_object_addition(&self, object: u64) -> Option<Box<dyn LayerObjectLookup>> {
         self.layer.lookup_object_addition(object)
     }
 
-    fn lookup_object_removal(&self, object: u64) -> Option<Box<dyn ObjectLookup>> {
+    fn lookup_object_removal(&self, object: u64) -> Option<Box<dyn LayerObjectLookup>> {
         self.layer.lookup_object_removal(object)
     }
 
-    fn lookup_predicate(&self, predicate: u64) -> Option<Box<dyn PredicateLookup>> {
-        self.layer.lookup_predicate(predicate)
-    }
-
-    fn lookup_predicate_addition(&self, predicate: u64) -> Option<Box<dyn PredicateLookup>> {
+    fn lookup_predicate_addition(&self, predicate: u64) -> Option<Box<dyn LayerPredicateLookup>> {
         self.layer.lookup_predicate_addition(predicate)
     }
 
-    fn lookup_predicate_removal(&self, predicate: u64) -> Option<Box<dyn PredicateLookup>> {
+    fn lookup_predicate_removal(&self, predicate: u64) -> Option<Box<dyn LayerPredicateLookup>> {
         self.layer.lookup_predicate_removal(predicate)
     }
 

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -11,7 +11,7 @@ use futures::sync::oneshot;
 use std::io;
 use std::path::PathBuf;
 
-use crate::layer::{Layer,ObjectType,StringTriple,IdTriple,SubjectLookup,ObjectLookup, PredicateLookup};
+use crate::layer::{Layer,ObjectType,StringTriple,IdTriple,SubjectLookup,LayerSubjectLookup,LayerObjectLookup,LayerPredicateLookup};
 use crate::store::{Store, NamedGraph, StoreLayer, StoreLayerBuilder, open_memory_store, open_directory_store};
 
 lazy_static! {
@@ -199,19 +199,15 @@ impl Layer for SyncStoreLayer {
         self.inner.id_object(id)
     }
 
-    fn subjects_current_layer(&self, parent: Box<dyn Iterator<Item=Box<dyn SubjectLookup>>>) -> Box<dyn Iterator<Item=Box<dyn SubjectLookup>>> {
-        self.inner.subjects_current_layer(parent)
-    }
-
     fn subjects(&self) -> Box<dyn Iterator<Item=Box<dyn SubjectLookup>>> {
         self.inner.subjects()
     }
 
-    fn subject_additions(&self) -> Box<dyn Iterator<Item=Box<dyn SubjectLookup>>> {
+    fn subject_additions(&self) -> Box<dyn Iterator<Item=Box<dyn LayerSubjectLookup>>> {
         self.inner.subject_additions()
     }
 
-    fn subject_removals(&self) -> Box<dyn Iterator<Item=Box<dyn SubjectLookup>>> {
+    fn subject_removals(&self) -> Box<dyn Iterator<Item=Box<dyn LayerSubjectLookup>>> {
         self.inner.subject_removals()
     }
 
@@ -219,60 +215,36 @@ impl Layer for SyncStoreLayer {
         self.inner.lookup_subject(subject)
     }
 
-    fn lookup_subject_addition(&self, subject: u64) -> Option<Box<dyn SubjectLookup>> {
+    fn lookup_subject_addition(&self, subject: u64) -> Option<Box<dyn LayerSubjectLookup>> {
         self.inner.lookup_subject_addition(subject)
     }
 
-    fn lookup_subject_removal(&self, subject: u64) -> Option<Box<dyn SubjectLookup>> {
+    fn lookup_subject_removal(&self, subject: u64) -> Option<Box<dyn LayerSubjectLookup>> {
         self.inner.lookup_subject_removal(subject)
     }
 
-    fn objects(&self) -> Box<dyn Iterator<Item=Box<dyn ObjectLookup>>> {
-        self.inner.objects()
-    }
-
-    fn object_additions(&self) -> Box<dyn Iterator<Item=Box<dyn ObjectLookup>>> {
+    fn object_additions(&self) -> Box<dyn Iterator<Item=Box<dyn LayerObjectLookup>>> {
         self.inner.object_additions()
     }
 
-    fn object_removals(&self) -> Box<dyn Iterator<Item=Box<dyn ObjectLookup>>> {
+    fn object_removals(&self) -> Box<dyn Iterator<Item=Box<dyn LayerObjectLookup>>> {
         self.inner.object_removals()
     }
 
-    fn lookup_object(&self, object: u64) -> Option<Box<dyn ObjectLookup>> {
-        self.inner.lookup_object(object)
-    }
-
-    fn lookup_object_addition(&self, object: u64) -> Option<Box<dyn ObjectLookup>> {
+    fn lookup_object_addition(&self, object: u64) -> Option<Box<dyn LayerObjectLookup>> {
         self.inner.lookup_object_addition(object)
     }
 
-    fn lookup_object_removal(&self, object: u64) -> Option<Box<dyn ObjectLookup>> {
+    fn lookup_object_removal(&self, object: u64) -> Option<Box<dyn LayerObjectLookup>> {
         self.inner.lookup_object_removal(object)
     }
 
-    fn lookup_predicate(&self, predicate: u64) -> Option<Box<dyn PredicateLookup>> {
-        self.inner.lookup_predicate(predicate)
-    }
-
-    fn lookup_predicate_addition(&self, predicate: u64) -> Option<Box<dyn PredicateLookup>> {
+    fn lookup_predicate_addition(&self, predicate: u64) -> Option<Box<dyn LayerPredicateLookup>> {
         self.inner.lookup_predicate_addition(predicate)
     }
 
-    fn lookup_predicate_removal(&self, predicate: u64) -> Option<Box<dyn PredicateLookup>> {
+    fn lookup_predicate_removal(&self, predicate: u64) -> Option<Box<dyn LayerPredicateLookup>> {
         self.inner.lookup_predicate_removal(predicate)
-    }
-
-    fn lookup_subject_current_layer(&self, subject: u64, parent: Option<Box<dyn SubjectLookup>>) -> Option<Box<dyn SubjectLookup>> {
-        self.inner.lookup_subject_current_layer(subject, parent)
-    }
-
-    fn lookup_predicate_current_layer(&self, predicate: u64, parent: Option<Box<dyn PredicateLookup>>) -> Option<Box<dyn PredicateLookup>> {
-        self.inner.lookup_predicate_current_layer(predicate, parent)
-    }
-
-    fn lookup_object_current_layer(&self, object: u64, parent: Option<Box<dyn ObjectLookup>>) -> Option<Box<dyn ObjectLookup>> {
-        self.inner.lookup_object_current_layer(object, parent)
     }
 
     fn clone_boxed(&self) -> Box<dyn Layer> {


### PR DESCRIPTION
Lookups have been refactored.

For each lookup type (SubjectLookup, SubjectPredicateLookup, PredicateLookup, ObjectLookup) there is now a 'Layer' version (LayerSubjectLookup, LayerSubjectPredciateLookup, LayerPredicateLookup, LayerObjectLookup) which represents a lookup in either the layer's additions or the layer's removals, without taking parent layers into account.

The original implementations for SubjectLookup, SubjectPredicateLookup, PredicateLookup and ObjectLookup have been removed, and have been replaced by single implementations, GenericSubjectLookup, GenericSubjectPredicateLookup, GenericPredicateLookup and GenericObjectLookup. These are implemented in terms of the new Layer Lookup traits.

Unlike the old Lookups these are not implemented recursively, so stack exhaustion should no longer be an issue.