### PR TITLE
src/structure: format and minimize trait bounds

### DIFF
--- a/src/structure/bitarray.rs
+++ b/src/structure/bitarray.rs
@@ -1,35 +1,35 @@
 //! Logic for storing, loading and using arrays of bits.
-use byteorder::{ByteOrder,BigEndian};
-use futures::prelude::*;
-use tokio::prelude::*;
-use tokio::codec::{FramedRead,Decoder};
-use bytes::BytesMut;
+
 use super::util::*;
+
 use crate::storage::*;
 
+use byteorder::{BigEndian, ByteOrder};
+use bytes::BytesMut;
+use futures::prelude::*;
+use tokio::codec::{Decoder, FramedRead};
+use tokio::prelude::*;
+
 #[derive(Clone)]
-pub struct BitArray<M:AsRef<[u8]>+Clone> {
+pub struct BitArray<M: AsRef<[u8]> + Clone> {
     bits: M,
     /// how many bits are being used in the last 8 bytes?
-    count: u64
+    count: u64,
 }
 
-impl<M:AsRef<[u8]>+Clone> BitArray<M> {
+impl<M: AsRef<[u8]> + Clone> BitArray<M> {
     pub fn from_bits(bits: M) -> BitArray<M> {
         if bits.as_ref().len() < 8 || bits.as_ref().len() % 8 != 0 {
             panic!("unexpected bitarray length");
         }
 
-        let count = BigEndian::read_u64(&bits.as_ref()[bits.as_ref().len()-8..]);
+        let count = BigEndian::read_u64(&bits.as_ref()[bits.as_ref().len() - 8..]);
 
-        BitArray {
-            bits,
-            count
-        }
+        BitArray { bits, count }
     }
 
     pub fn bits(&self) -> &[u8] {
-        &self.bits.as_ref()[..self.bits.as_ref().len()-8]
+        &self.bits.as_ref()[..self.bits.as_ref().len() - 8]
     }
 
     pub fn len(&self) -> usize {
@@ -41,45 +41,60 @@ impl<M:AsRef<[u8]>+Clone> BitArray<M> {
             panic!("index too high");
         }
 
-        let byte = self.bits.as_ref()[index/8];
-        let mask: u8 = 128>>(index%8);
+        let byte = self.bits.as_ref()[index / 8];
+        let mask: u8 = 128 >> (index % 8);
 
         byte & mask != 0
     }
 }
 
 pub struct BitArrayFileBuilder<W>
-where W: 'static+AsyncWrite+Send {
+where
+    W: 'static + AsyncWrite + Send,
+{
     current_byte: u8,
     current_bit_pos: u8,
     bit_output: W,
-    pub count: u64
+    pub count: u64,
 }
 
 impl<W> BitArrayFileBuilder<W>
-where W: 'static+AsyncWrite+Send {
+where
+    W: 'static + AsyncWrite + Send,
+{
     pub fn new(output: W) -> BitArrayFileBuilder<W> {
         BitArrayFileBuilder {
             current_byte: 0,
             current_bit_pos: 0,
             bit_output: output,
-            count: 0
+            count: 0,
         }
     }
 
-    fn flush_current(self) -> Box<dyn Future<Item=BitArrayFileBuilder<W>, Error=std::io::Error>+Send> {
+    fn flush_current(
+        self,
+    ) -> Box<dyn Future<Item = BitArrayFileBuilder<W>, Error = std::io::Error> + Send> {
         let count = self.count;
-        Box::new(tokio::io::write_all(self.bit_output, vec![self.current_byte])
-                 .map(move |(w,_)| BitArrayFileBuilder {
-                     current_byte: 0,
-                     current_bit_pos: 0,
-                     bit_output: w,
-                     count: count
-                 }))
+        Box::new(
+            tokio::io::write_all(self.bit_output, vec![self.current_byte]).map(move |(w, _)| {
+                BitArrayFileBuilder {
+                    current_byte: 0,
+                    current_bit_pos: 0,
+                    bit_output: w,
+                    count: count,
+                }
+            }),
+        )
     }
 
-    pub fn push(mut self, bit: bool) -> Box<dyn Future<Item=BitArrayFileBuilder<W>, Error=std::io::Error>+Send> {
-        let mut b = match bit { true => 128, false => 0 };
+    pub fn push(
+        mut self,
+        bit: bool,
+    ) -> Box<dyn Future<Item = BitArrayFileBuilder<W>, Error = std::io::Error> + Send> {
+        let mut b = match bit {
+            true => 128,
+            false => 0,
+        };
         b >>= self.current_bit_pos;
         self.current_byte |= b;
         self.current_bit_pos += 1;
@@ -87,29 +102,32 @@ where W: 'static+AsyncWrite+Send {
 
         if self.current_bit_pos == 8 {
             self.flush_current()
-        }
-        else {
+        } else {
             Box::new(future::ok(self))
         }
     }
 
-    pub fn push_all<S:'static+Stream<Item=bool,Error=std::io::Error>+Send>(self, stream: S) -> Box<dyn Future<Item=BitArrayFileBuilder<W>,Error=std::io::Error>+Send> {
+    pub fn push_all<S: 'static + Stream<Item = bool, Error = std::io::Error> + Send>(
+        self,
+        stream: S,
+    ) -> Box<dyn Future<Item = BitArrayFileBuilder<W>, Error = std::io::Error> + Send> {
         Box::new(stream.fold(self, |builder, bit| builder.push(bit)))
     }
 
-    fn pad(self) -> impl Future<Item=W, Error=std::io::Error> {
-        write_padding(self.bit_output, (self.count as usize+7)/8, 8)
-            .map(|(bit_output,_)| bit_output)
+    fn pad(self) -> impl Future<Item = W, Error = std::io::Error> {
+        write_padding(self.bit_output, (self.count as usize + 7) / 8, 8)
+            .map(|(bit_output, _)| bit_output)
     }
 
-    pub fn finalize(self) -> impl Future<Item=W, Error=std::io::Error> {
+    pub fn finalize(self) -> impl Future<Item = W, Error = std::io::Error> {
         let count = self.count;
-        let flush_current: Box<dyn Future<Item=BitArrayFileBuilder<W>,Error=std::io::Error>+Send> =
-            if count % 8 == 0 {
-                Box::new(future::ok(self))
-            } else {
-                Box::new(self.flush_current())
-            };
+        let flush_current: Box<
+            dyn Future<Item = BitArrayFileBuilder<W>, Error = std::io::Error> + Send,
+        > = if count % 8 == 0 {
+            Box::new(future::ok(self))
+        } else {
+            Box::new(self.flush_current())
+        };
 
         flush_current
             .and_then(|b| b.pad())
@@ -123,7 +141,7 @@ where W: 'static+AsyncWrite+Send {
 }
 
 pub struct BitArrayBlockDecoder {
-    readahead: Option<u64>
+    readahead: Option<u64>,
 }
 
 impl Decoder for BitArrayBlockDecoder {
@@ -141,19 +159,19 @@ impl Decoder for BitArrayBlockDecoder {
         self.readahead = Some(read);
         match current {
             None => self.decode(src),
-            Some(ra) => Ok(Some(ra))
+            Some(ra) => Ok(Some(ra)),
         }
     }
 }
 
-pub fn bitarray_stream_blocks<R:AsyncRead>(r: R) -> FramedRead<R, BitArrayBlockDecoder> {
+pub fn bitarray_stream_blocks<R: AsyncRead>(r: R) -> FramedRead<R, BitArrayBlockDecoder> {
     FramedRead::new(r, BitArrayBlockDecoder { readahead: None })
 }
 
-fn bitarray_count_from_file<F:FileLoad>(f: F) -> impl Future<Item=u64, Error=std::io::Error> {
+fn bitarray_count_from_file<F: FileLoad>(f: F) -> impl Future<Item = u64, Error = std::io::Error> {
     let offset = f.size() - 8;
-    tokio::io::read_exact(f.open_read_from(offset), vec![0;8])
-        .map(|(_,buf)| BigEndian::read_u64(&buf))
+    tokio::io::read_exact(f.open_read_from(offset), vec![0; 8])
+        .map(|(_, buf)| BigEndian::read_u64(&buf))
 }
 
 fn block_bits(block: u64) -> Vec<bool> {
@@ -167,13 +185,17 @@ fn block_bits(block: u64) -> Vec<bool> {
     result
 }
 
-pub fn bitarray_stream_bits<F:FileLoad+Clone>(f: F) -> impl Stream<Item=bool, Error=std::io::Error> {
+pub fn bitarray_stream_bits<F: FileLoad + Clone>(
+    f: F,
+) -> impl Stream<Item = bool, Error = std::io::Error> {
     bitarray_count_from_file(f.clone())
         .into_stream()
-        .map(move |count| bitarray_stream_blocks(f.open_read())
-             .map(|block| stream::iter_ok(block_bits(block).into_iter()))
-             .flatten()
-             .take(count))
+        .map(move |count| {
+            bitarray_stream_blocks(f.open_read())
+                .map(|block| stream::iter_ok(block_bits(block).into_iter()))
+                .flatten()
+                .take(count)
+        })
         .flatten()
 }
 
@@ -185,11 +207,12 @@ mod tests {
     #[test]
     pub fn construct_and_parse_small_bitarray() {
         let x = MemoryBackedStore::new();
-        let contents = vec![true,true,false,false,true];
+        let contents = vec![true, true, false, false, true];
 
         let builder = BitArrayFileBuilder::new(x.open_write());
-        let _written = builder.push_all(stream::iter_ok(contents))
-            .and_then(|b|b.finalize())
+        let _written = builder
+            .push_all(stream::iter_ok(contents))
+            .and_then(|b| b.finalize())
             .wait()
             .unwrap();
 
@@ -210,8 +233,9 @@ mod tests {
         let contents = (0..).map(|n| n % 3 == 0).take(123456);
 
         let builder = BitArrayFileBuilder::new(x.open_write());
-        let _written = builder.push_all(stream::iter_ok(contents))
-            .and_then(|b|b.finalize())
+        let _written = builder
+            .push_all(stream::iter_ok(contents))
+            .and_then(|b| b.finalize())
             .wait()
             .unwrap();
 
@@ -229,16 +253,19 @@ mod tests {
         let x = MemoryBackedStore::new();
         let contents = (0..).map(|n| n % 4 == 1).take(256);
 
-
         let builder = BitArrayFileBuilder::new(x.open_write());
-        let _written = builder.push_all(stream::iter_ok(contents))
-            .and_then(|b|b.finalize())
+        let _written = builder
+            .push_all(stream::iter_ok(contents))
+            .and_then(|b| b.finalize())
             .wait()
             .unwrap();
 
         let stream = bitarray_stream_blocks(x.open_read());
 
-        stream.for_each(|block| Ok(assert_eq!(0x4444444444444444, block))).wait().unwrap();
+        stream
+            .for_each(|block| Ok(assert_eq!(0x4444444444444444, block)))
+            .wait()
+            .unwrap();
     }
 
     #[test]
@@ -246,10 +273,10 @@ mod tests {
         let x = MemoryBackedStore::new();
         let contents: Vec<_> = (0..).map(|n| n % 4 == 1).take(123).collect();
 
-
         let builder = BitArrayFileBuilder::new(x.open_write());
-        let _written = builder.push_all(stream::iter_ok(contents.clone()))
-            .and_then(|b|b.finalize())
+        let _written = builder
+            .push_all(stream::iter_ok(contents.clone()))
+            .and_then(|b| b.finalize())
             .wait()
             .unwrap();
 

--- a/src/structure/logarray.rs
+++ b/src/structure/logarray.rs
@@ -4,40 +4,41 @@
 //! By using the minimal width necessary to store the largest value of
 //! the array, the byte representation of the array can be compressed
 //! significantly compared to using an array of u64.
-use tokio::codec::{FramedRead,Decoder};
-use byteorder::{ByteOrder,BigEndian};
-use bytes::BytesMut;
-use futures::prelude::*;
-use futures::future;
+
 use crate::storage::*;
+
+use byteorder::{BigEndian, ByteOrder};
+use bytes::BytesMut;
+use futures::future;
+use futures::prelude::*;
 use std::cmp::Ordering;
+use tokio::codec::{Decoder, FramedRead};
 
 #[derive(Clone)]
-pub struct LogArray<M:AsRef<[u8]>+Clone> {
+pub struct LogArray<M: AsRef<[u8]> + Clone> {
     len: u32,
     width: u8,
     len_bytes: usize,
-    data: M
+    data: M,
 }
 
 #[derive(Debug)]
 pub enum LogArrayError {
-    InvalidCoding
+    InvalidCoding,
 }
 
-pub struct LogArrayIterator<'a, M:AsRef<[u8]>+Clone> {
+pub struct LogArrayIterator<'a, M: AsRef<[u8]> + Clone> {
     logarray: &'a LogArray<M>,
     pos: usize,
-    end: usize
+    end: usize,
 }
 
-impl<'a, M:AsRef<[u8]>+Clone> Iterator for LogArrayIterator<'a, M> {
+impl<'a, M: AsRef<[u8]> + Clone> Iterator for LogArrayIterator<'a, M> {
     type Item = u64;
     fn next(&mut self) -> Option<u64> {
         if self.pos == self.end {
             None
-        }
-        else {
+        } else {
             let result = self.logarray.entry(self.pos);
             self.pos += 1;
 
@@ -46,19 +47,18 @@ impl<'a, M:AsRef<[u8]>+Clone> Iterator for LogArrayIterator<'a, M> {
     }
 }
 
-pub struct OwnedLogArrayIterator<M:AsRef<[u8]>+Clone> {
+pub struct OwnedLogArrayIterator<M: AsRef<[u8]> + Clone> {
     logarray: LogArray<M>,
     pos: usize,
-    end: usize
+    end: usize,
 }
 
-impl<M:AsRef<[u8]>+Clone> Iterator for OwnedLogArrayIterator<M> {
+impl<M: AsRef<[u8]> + Clone> Iterator for OwnedLogArrayIterator<M> {
     type Item = u64;
     fn next(&mut self) -> Option<u64> {
         if self.pos == self.end {
             None
-        }
-        else {
+        } else {
             let result = self.logarray.entry(self.pos);
             self.pos += 1;
 
@@ -67,19 +67,23 @@ impl<M:AsRef<[u8]>+Clone> Iterator for OwnedLogArrayIterator<M> {
     }
 }
 
-impl<M:AsRef<[u8]>+Clone> LogArray<M> {
-    pub fn parse(data: M) -> Result<LogArray<M>,LogArrayError> {
-        let len = BigEndian::read_u32(&data.as_ref()[data.as_ref().len()-8..]);
-        let width = data.as_ref()[data.as_ref().len()-4];
+impl<M: AsRef<[u8]> + Clone> LogArray<M> {
+    pub fn parse(data: M) -> Result<LogArray<M>, LogArrayError> {
+        let len = BigEndian::read_u32(&data.as_ref()[data.as_ref().len() - 8..]);
+        let width = data.as_ref()[data.as_ref().len() - 4];
         let len_bytes = (len as usize * width as usize + 7) / 8 as usize;
 
-        assert_eq!((len_bytes+15)/8*8, data.as_ref().len(), "logarray data is of wrong length");
+        assert_eq!(
+            (len_bytes + 15) / 8 * 8,
+            data.as_ref().len(),
+            "logarray data is of wrong length"
+        );
 
         Ok(LogArray {
             len,
             width,
             len_bytes,
-            data
+            data,
         })
     }
 
@@ -103,39 +107,38 @@ impl<M:AsRef<[u8]>+Clone> LogArray<M> {
 
         if start_u64_offset + 16 > self.len_bytes {
             let fragment_size = self.len_bytes - start_u64_offset;
-            let mut x = vec![0;16];
-            x[..fragment_size].copy_from_slice(&self.data.as_ref()[start_u64_offset..self.len_bytes]);
+            let mut x = vec![0; 16];
+            x[..fragment_size]
+                .copy_from_slice(&self.data.as_ref()[start_u64_offset..self.len_bytes]);
 
             let n1 = BigEndian::read_u64(&x);
             let n2 = BigEndian::read_u64(&x[8..]);
-            (n1,n2)
-        }
-        else {
+            (n1, n2)
+        } else {
             let n1 = BigEndian::read_u64(&self.data.as_ref()[start_u64_offset..self.len_bytes]);
-            let n2 = BigEndian::read_u64(&self.data.as_ref()[start_u64_offset+8..self.len_bytes]);
-            (n1,n2)
+            let n2 = BigEndian::read_u64(&self.data.as_ref()[start_u64_offset + 8..self.len_bytes]);
+            (n1, n2)
         }
     }
 
-    fn shift_for_index(&self, index:usize) -> i8 {
+    fn shift_for_index(&self, index: usize) -> i8 {
         64 - self.width as i8 - (index * self.width as usize % 64) as i8
     }
 
-    pub fn entry(&self, index:usize) -> u64 {
-        let (n1,n2) = self.nums_for_index(index);
+    pub fn entry(&self, index: usize) -> u64 {
+        let (n1, n2) = self.nums_for_index(index);
         let shift_for_index = self.shift_for_index(index);
         if shift_for_index < 0 {
             // crossing an u64 boundary. we need to shift left
             let mut x = n1;
             x <<= 64 - (self.width as i8 + shift_for_index) as u8;
-            x >>= 64-self.width; // x contains the first part in the correct position
+            x >>= 64 - self.width; // x contains the first part in the correct position
             let mut y = n2;
             y >>= 64 + shift_for_index;
             x |= y;
 
             x
-        }
-        else {
+        } else {
             // no boundaries are crossed. all that matters is n1
             let mut x = n1;
             x <<= 64 - (self.width as i8 + shift_for_index) as u8;
@@ -149,7 +152,7 @@ impl<M:AsRef<[u8]>+Clone> LogArray<M> {
         LogArrayIterator {
             logarray: self,
             pos: 0,
-            end: self.len()
+            end: self.len(),
         }
     }
 
@@ -168,19 +171,19 @@ impl<M:AsRef<[u8]>+Clone> LogArray<M> {
         LogArraySlice {
             original: self.clone(),
             offset,
-            length
+            length,
         }
     }
 }
 
 #[derive(Clone)]
-pub struct LogArraySlice<M:AsRef<[u8]>+Clone> {
+pub struct LogArraySlice<M: AsRef<[u8]> + Clone> {
     original: LogArray<M>,
     offset: usize,
-    length: usize
+    length: usize,
 }
 
-impl<M:AsRef<[u8]>+Clone> LogArraySlice<M> {
+impl<M: AsRef<[u8]> + Clone> LogArraySlice<M> {
     pub fn len(&self) -> usize {
         self.length
     }
@@ -190,14 +193,14 @@ impl<M:AsRef<[u8]>+Clone> LogArraySlice<M> {
             panic!("index too large for slice");
         }
 
-        self.original.entry(index+self.offset)
+        self.original.entry(index + self.offset)
     }
 
     pub fn iter(&self) -> LogArrayIterator<M> {
         LogArrayIterator {
             logarray: &self.original,
             pos: self.offset,
-            end: self.offset + self.length
+            end: self.offset + self.length,
         }
     }
 
@@ -211,26 +214,29 @@ impl<M:AsRef<[u8]>+Clone> LogArraySlice<M> {
 }
 
 /// write a logarray directly to an AsyncWrite
-pub struct LogArrayFileBuilder<W:'static+tokio::io::AsyncWrite+Send> {
+pub struct LogArrayFileBuilder<W: 'static + tokio::io::AsyncWrite + Send> {
     file: W,
     width: u8,
     current: u64,
     current_offset: u8,
-    pub count: u32
+    pub count: u32,
 }
 
-impl<W:'static+tokio::io::AsyncWrite+Send> LogArrayFileBuilder<W> {
+impl<W: 'static + tokio::io::AsyncWrite + Send> LogArrayFileBuilder<W> {
     pub fn new(w: W, width: u8) -> LogArrayFileBuilder<W> {
         LogArrayFileBuilder {
             file: w,
             width: width,
             current: 0,
             current_offset: 0,
-            count: 0
+            count: 0,
         }
     }
 
-    pub fn push(mut self, val: u64) -> Box<dyn Future<Item=LogArrayFileBuilder<W>,Error=std::io::Error>+Send> {
+    pub fn push(
+        mut self,
+        val: u64,
+    ) -> Box<dyn Future<Item = LogArrayFileBuilder<W>, Error = std::io::Error> + Send> {
         if val.leading_zeros() < 64 - self.width as u32 {
             panic!("value {} too large for width {}", val, self.width);
         }
@@ -243,63 +249,70 @@ impl<W:'static+tokio::io::AsyncWrite+Send> LogArrayFileBuilder<W> {
 
         if self.current_offset + self.width >= 64 {
             // we filled up 64 bits, time to write
-            let mut buf = vec![0u8;8];
+            let mut buf = vec![0u8; 8];
             BigEndian::write_u64(&mut buf, self.current);
 
             let new_offset = self.current_offset + self.width - 64;
-            let remainder = if new_offset == 0 { 0 } else { val << (64 - new_offset) };
+            let remainder = if new_offset == 0 {
+                0
+            } else {
+                val << (64 - new_offset)
+            };
 
             let LogArrayFileBuilder {
                 file,
                 width,
                 count,
                 current: _,
-                current_offset: _
+                current_offset: _,
             } = self;
 
-            Box::new(tokio::io::write_all(file, buf)
-                     .map(move |(file, _)| LogArrayFileBuilder {
-                         file: file,
-                         width: width,
-                         current: remainder,
-                         current_offset: new_offset,
-                         count: count
-                     }))
-        }
-        else {
+            Box::new(
+                tokio::io::write_all(file, buf).map(move |(file, _)| LogArrayFileBuilder {
+                    file: file,
+                    width: width,
+                    current: remainder,
+                    current_offset: new_offset,
+                    count: count,
+                }),
+            )
+        } else {
             self.current_offset += self.width;
             Box::new(future::ok(self))
         }
     }
 
-    pub fn push_all<S:Stream<Item=u64,Error=std::io::Error>>(self, vals: S) -> impl Future<Item=LogArrayFileBuilder<W>,Error=std::io::Error> {
+    pub fn push_all<S: Stream<Item = u64, Error = std::io::Error>>(
+        self,
+        vals: S,
+    ) -> impl Future<Item = LogArrayFileBuilder<W>, Error = std::io::Error> {
         vals.fold(self, |x, val| x.push(val))
     }
 
-    pub fn finalize(self) -> impl Future<Item=W, Error=std::io::Error> {
+    pub fn finalize(self) -> impl Future<Item = W, Error = std::io::Error> {
         let LogArrayFileBuilder {
-            file, width, count, current, current_offset: _
+            file,
+            width,
+            count,
+            current,
+            current_offset: _,
         } = self;
 
+        let write_last_bits: Box<dyn Future<Item = W, Error = std::io::Error> + Send> =
+            if (count as u64) * (width as u64) % 64 == 0 {
+                Box::new(future::ok(file))
+            } else {
+                let mut buf = vec![0u8; 8];
+                BigEndian::write_u64(&mut buf, current);
+                Box::new(tokio::io::write_all(file, buf).map(|(file, _)| file))
+            };
 
-        let write_last_bits: Box<dyn Future<Item=W, Error=std::io::Error>+Send> = if (count as u64)*(width as u64) % 64 == 0 {
-            Box::new(future::ok(file))
-        }
-        else {
-            let mut buf = vec![0u8;8];
-            BigEndian::write_u64(&mut buf, current);
-            Box::new(tokio::io::write_all(file, buf)
-                     .map(|(file,_)|file))
-        };
-
-        write_last_bits
-            .and_then(move |file| {
-                let mut buf = vec![0u8;8];
-                BigEndian::write_u32(&mut buf, count);
-                buf[4] = width;
-                tokio::io::write_all(file, buf)
-                     .map(|(file,_)|file)
-            })
+        write_last_bits.and_then(move |file| {
+            let mut buf = vec![0u8; 8];
+            BigEndian::write_u32(&mut buf, count);
+            buf[4] = width;
+            tokio::io::write_all(file, buf).map(|(file, _)| file)
+        })
     }
 }
 
@@ -308,7 +321,7 @@ pub struct LogArrayDecoder {
     current: u64,
     width: u8,
     offset: u8,
-    remaining: u32
+    remaining: u32,
 }
 
 impl Decoder for LogArrayDecoder {
@@ -323,7 +336,7 @@ impl Decoder for LogArrayDecoder {
         }
         if self.offset + self.width <= 64 {
             // we can just return the first thingie no problem
-            let result = (self.current << self.offset) >> (64-self.width);
+            let result = (self.current << self.offset) >> (64 - self.width);
             self.offset += self.width;
             self.remaining -= 1;
             return Ok(Some(result));
@@ -346,9 +359,8 @@ impl Decoder for LogArrayDecoder {
             // in that case, we start at the beginning of the number just read.
             self.offset = self.width;
 
-            return Ok(Some(fragment>>(64-self.width)));
-        }
-        else {
+            return Ok(Some(fragment >> (64 - self.width)));
+        } else {
             // we've not yet reached the end of our current 64 bit chunk. the current entry is divided over the current and the next chunk.
             let big: u64 = (current << self.offset) >> self.offset;
             let big_len = 64 - self.offset;
@@ -362,29 +374,42 @@ impl Decoder for LogArrayDecoder {
     }
 }
 
-pub fn logarray_file_get_length_and_width<F:FileLoad>(f: &F) -> impl Future<Item=(u32,u8),Error=std::io::Error> {
+pub fn logarray_file_get_length_and_width<F: FileLoad>(
+    f: &F,
+) -> impl Future<Item = (u32, u8), Error = std::io::Error> {
     let end_offset = f.size() - 8;
     // read the length and width
-    tokio::io::read_exact(f.open_read_from(end_offset), vec![0;8])
-        .map(move |(_,buf)| {
-            let len = BigEndian::read_u32(&buf);
-            let width = buf[4];
+    tokio::io::read_exact(f.open_read_from(end_offset), vec![0; 8]).map(move |(_, buf)| {
+        let len = BigEndian::read_u32(&buf);
+        let width = buf[4];
 
-            (len, width)
-        })
+        (len, width)
+    })
 }
 
-pub fn logarray_stream_entries<F:FileLoad>(f: F) -> impl Stream<Item=u64,Error=std::io::Error> {
+pub fn logarray_stream_entries<F: FileLoad>(
+    f: F,
+) -> impl Stream<Item = u64, Error = std::io::Error> {
     logarray_file_get_length_and_width(&f)
-        .map(move |(len, width)| FramedRead::new(f.open_read(), LogArrayDecoder { current: 0, width, offset: 64, remaining: len }))
+        .map(move |(len, width)| {
+            FramedRead::new(
+                f.open_read(),
+                LogArrayDecoder {
+                    current: 0,
+                    width,
+                    offset: 64,
+                    remaining: len,
+                },
+            )
+        })
         .into_stream()
         .flatten()
 }
 
 #[derive(Clone)]
-pub struct MonotonicLogArray<M:AsRef<[u8]>+Clone>(LogArray<M>);
+pub struct MonotonicLogArray<M: AsRef<[u8]> + Clone>(LogArray<M>);
 
-impl<M:AsRef<[u8]>+Clone> MonotonicLogArray<M> {
+impl<M: AsRef<[u8]> + Clone> MonotonicLogArray<M> {
     pub fn from_logarray(logarray: LogArray<M>) -> MonotonicLogArray<M> {
         if cfg!(debug_assertions) {
             let mut iter = logarray.iter();
@@ -407,7 +432,7 @@ impl<M:AsRef<[u8]>+Clone> MonotonicLogArray<M> {
         self.0.len()
     }
 
-    pub fn entry(&self, index:usize) -> u64 {
+    pub fn entry(&self, index: usize) -> u64 {
         self.0.entry(index)
     }
 
@@ -430,7 +455,7 @@ impl<M:AsRef<[u8]>+Clone> MonotonicLogArray<M> {
             let mid = (min + max) / 2;
             match element.cmp(&self.entry(mid)) {
                 Ordering::Equal => return Some(mid),
-                Ordering::Greater => min = mid+1,
+                Ordering::Greater => min = mid + 1,
                 Ordering::Less => {
                     if mid == 0 {
                         return None;
@@ -442,7 +467,6 @@ impl<M:AsRef<[u8]>+Clone> MonotonicLogArray<M> {
 
         None
     }
-
 }
 
 #[cfg(test)]
@@ -455,7 +479,8 @@ mod tests {
     fn generate_then_parse_works() {
         let store = MemoryBackedStore::new();
         let builder = LogArrayFileBuilder::new(store.open_write(), 5);
-        builder.push_all(stream::iter_ok(vec![1,3,2,5,12,31,18]))
+        builder
+            .push_all(stream::iter_ok(vec![1, 3, 2, 5, 12, 31, 18]))
             .and_then(|b| b.finalize())
             .wait()
             .unwrap();
@@ -477,14 +502,13 @@ mod tests {
     fn generate_then_stream_works() {
         let store = MemoryBackedStore::new();
         let builder = LogArrayFileBuilder::new(store.open_write(), 5);
-        builder.push_all(stream::iter_ok(0..31))
+        builder
+            .push_all(stream::iter_ok(0..31))
             .and_then(|b| b.finalize())
             .wait()
             .unwrap();
 
-        let entries: Vec<u64> = logarray_stream_entries(store).collect()
-            .wait()
-            .unwrap();
+        let entries: Vec<u64> = logarray_stream_entries(store).collect().wait().unwrap();
 
         let expected: Vec<u64> = (0..31).collect();
 
@@ -495,8 +519,9 @@ mod tests {
     fn iterate_over_logarray() {
         let store = MemoryBackedStore::new();
         let builder = LogArrayFileBuilder::new(store.open_write(), 5);
-        let original = vec![1,3,2,5,12,31,18];
-        builder.push_all(stream::iter_ok(original.clone()))
+        let original = vec![1, 3, 2, 5, 12, 31, 18];
+        builder
+            .push_all(stream::iter_ok(original.clone()))
             .and_then(|b| b.finalize())
             .wait()
             .unwrap();
@@ -514,8 +539,9 @@ mod tests {
     fn owned_iterate_over_logarray() {
         let store = MemoryBackedStore::new();
         let builder = LogArrayFileBuilder::new(store.open_write(), 5);
-        let original = vec![1,3,2,5,12,31,18];
-        builder.push_all(stream::iter_ok(original.clone()))
+        let original = vec![1, 3, 2, 5, 12, 31, 18];
+        builder
+            .push_all(stream::iter_ok(original.clone()))
             .and_then(|b| b.finalize())
             .wait()
             .unwrap();
@@ -533,8 +559,9 @@ mod tests {
     fn iterate_over_logarray_slice() {
         let store = MemoryBackedStore::new();
         let builder = LogArrayFileBuilder::new(store.open_write(), 5);
-        let original = vec![1,3,2,5,12,31,18];
-        builder.push_all(stream::iter_ok(original.clone()))
+        let original = vec![1, 3, 2, 5, 12, 31, 18];
+        builder
+            .push_all(stream::iter_ok(original.clone()))
             .and_then(|b| b.finalize())
             .wait()
             .unwrap();
@@ -542,19 +569,20 @@ mod tests {
         let content = store.map().wait().unwrap();
 
         let logarray = LogArray::parse(&content).unwrap();
-        let slice = logarray.slice(2,3);
+        let slice = logarray.slice(2, 3);
 
         let result: Vec<u64> = slice.iter().collect();
 
-        assert_eq!(vec![2,5,12], result);
+        assert_eq!(vec![2, 5, 12], result);
     }
 
     #[test]
     fn owned_iterate_over_logarray_slice() {
         let store = MemoryBackedStore::new();
         let builder = LogArrayFileBuilder::new(store.open_write(), 5);
-        let original = vec![1,3,2,5,12,31,18];
-        builder.push_all(stream::iter_ok(original.clone()))
+        let original = vec![1, 3, 2, 5, 12, 31, 18];
+        builder
+            .push_all(stream::iter_ok(original.clone()))
             .and_then(|b| b.finalize())
             .wait()
             .unwrap();
@@ -562,19 +590,20 @@ mod tests {
         let content = store.map().wait().unwrap();
 
         let logarray = LogArray::parse(&content).unwrap();
-        let slice = logarray.slice(2,3);
+        let slice = logarray.slice(2, 3);
 
         let result: Vec<u64> = slice.into_iter().collect();
 
-        assert_eq!(vec![2,5,12], result);
+        assert_eq!(vec![2, 5, 12], result);
     }
 
     #[test]
     fn monotonic_logarray_index_lookup() {
         let store = MemoryBackedStore::new();
         let builder = LogArrayFileBuilder::new(store.open_write(), 5);
-        let original = vec![1,3,5,6,7,10,11,15,16,18,20,25,31];
-        builder.push_all(stream::iter_ok(original.clone()))
+        let original = vec![1, 3, 5, 6, 7, 10, 11, 15, 16, 18, 20, 25, 31];
+        builder
+            .push_all(stream::iter_ok(original.clone()))
             .and_then(|b| b.finalize())
             .wait()
             .unwrap();
@@ -594,10 +623,11 @@ mod tests {
     #[test]
     fn writing_64_bits_of_data() {
         let store = MemoryBackedStore::new();
-        let original = vec![1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8];
+        let original = vec![1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8];
         let builder = LogArrayFileBuilder::new(store.open_write(), 4);
-        builder.push_all(stream::iter_ok(original.clone()))
-            .and_then(|b|b.finalize())
+        builder
+            .push_all(stream::iter_ok(original.clone()))
+            .and_then(|b| b.finalize())
             .wait()
             .unwrap();
 
@@ -606,5 +636,4 @@ mod tests {
         assert_eq!(original, logarray.iter().collect::<Vec<_>>());
         assert_eq!(16, logarray.data.0.len());
     }
-
 }

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -2,18 +2,20 @@
 //!
 //! This module contains various succinct data structures, as well as
 //! the logic to load, parse and store them.
+
 mod util;
-pub mod vbyte;
-pub mod logarray;
-pub mod bitarray;
-pub mod pfc;
-pub mod bitindex;
+
 pub mod adjacencylist;
+pub mod bitarray;
+pub mod bitindex;
+pub mod logarray;
+pub mod pfc;
+pub mod vbyte;
 pub mod wavelettree;
 
-pub use logarray::*;
-pub use bitarray::*;
-pub use pfc::*;
-pub use bitindex::*;
 pub use adjacencylist::*;
+pub use bitarray::*;
+pub use bitindex::*;
+pub use logarray::*;
+pub use pfc::*;
 pub use wavelettree::*;

--- a/src/structure/pfc.rs
+++ b/src/structure/pfc.rs
@@ -1,19 +1,20 @@
 //! Implementation for a Plain Front-Coding (PFC) dictionary.
-use byteorder::{ByteOrder,BigEndian};
-use futures::prelude::*;
-use futures::future;
-use std::error::Error;
-use std::fmt::Display;
-use std::cmp::{Ord, Ordering};
 
-use super::vbyte::*;
 use super::logarray::*;
 use super::util::*;
+use super::vbyte::*;
+
+use byteorder::{BigEndian, ByteOrder};
+use futures::future;
+use futures::prelude::*;
+use std::cmp::{Ord, Ordering};
+use std::error::Error;
+use std::fmt::Display;
 
 #[derive(Debug)]
 pub enum PfcError {
     InvalidCoding,
-    NotEnoughData
+    NotEnoughData,
 }
 
 impl Display for PfcError {
@@ -34,8 +35,7 @@ impl From<LogArrayError> for PfcError {
     }
 }
 
-impl Error for PfcError {
-}
+impl Error for PfcError {}
 
 impl Into<std::io::Error> for PfcError {
     fn into(self) -> std::io::Error {
@@ -44,21 +44,21 @@ impl Into<std::io::Error> for PfcError {
 }
 
 #[derive(Clone)]
-pub struct PfcBlock<M:AsRef<[u8]>+Clone> {
+pub struct PfcBlock<M: AsRef<[u8]> + Clone> {
     encoded_strings: M,
-    n_strings: usize
+    n_strings: usize,
 }
 
 const BLOCK_SIZE: usize = 8;
 
-pub struct PfcBlockIterator<'a,M:AsRef<[u8]>+Clone> {
+pub struct PfcBlockIterator<'a, M: AsRef<[u8]> + Clone> {
     block: &'a PfcBlock<M>,
     count: usize,
     pos: usize,
-    string: Vec<u8>
+    string: Vec<u8>,
 }
 
-impl<'a, M:AsRef<[u8]>+Clone> Iterator for PfcBlockIterator<'a,M> {
+impl<'a, M: AsRef<[u8]> + Clone> Iterator for PfcBlockIterator<'a, M> {
     type Item = String;
 
     fn next(&mut self) -> Option<String> {
@@ -68,22 +68,26 @@ impl<'a, M:AsRef<[u8]>+Clone> Iterator for PfcBlockIterator<'a,M> {
 
             self.count = 1;
             self.pos = self.string.len() + 1;
-        }
-        else if self.count < self.block.n_strings {
+        } else if self.count < self.block.n_strings {
             // at pos we read a vbyte with the length of the common prefix
-            let v = VByte::parse(&self.block.encoded_strings.as_ref()[self.pos..]).expect("encoding error in self-managed data");
+            let v = VByte::parse(&self.block.encoded_strings.as_ref()[self.pos..])
+                .expect("encoding error in self-managed data");
             self.string.truncate(v.unpack() as usize);
             self.pos += v.len();
 
             // next up is the suffix, again as a nul-terminated string.
-            let postfix_end = self.pos + self.block.encoded_strings.as_ref()[self.pos..].iter().position(|&b|b==0).unwrap();
+            let postfix_end = self.pos
+                + self.block.encoded_strings.as_ref()[self.pos..]
+                    .iter()
+                    .position(|&b| b == 0)
+                    .unwrap();
 
-            self.string.extend_from_slice(&self.block.encoded_strings.as_ref()[self.pos..postfix_end]);
+            self.string
+                .extend_from_slice(&self.block.encoded_strings.as_ref()[self.pos..postfix_end]);
 
             self.pos = postfix_end + 1;
             self.count += 1;
-        }
-        else {
+        } else {
             return None;
         }
 
@@ -92,14 +96,14 @@ impl<'a, M:AsRef<[u8]>+Clone> Iterator for PfcBlockIterator<'a,M> {
 }
 
 // the owned version is pretty much equivalent. There should be a way to make this one implementation with generics but I haven't figured out how!
-pub struct OwnedPfcBlockIterator<M:AsRef<[u8]>+Clone> {
+pub struct OwnedPfcBlockIterator<M: AsRef<[u8]> + Clone> {
     block: PfcBlock<M>,
     count: usize,
     pos: usize,
-    string: Vec<u8>
+    string: Vec<u8>,
 }
 
-impl<M:AsRef<[u8]>+Clone> Iterator for OwnedPfcBlockIterator<M> {
+impl<M: AsRef<[u8]> + Clone> Iterator for OwnedPfcBlockIterator<M> {
     type Item = String;
 
     fn next(&mut self) -> Option<String> {
@@ -109,22 +113,26 @@ impl<M:AsRef<[u8]>+Clone> Iterator for OwnedPfcBlockIterator<M> {
 
             self.count = 1;
             self.pos = self.string.len() + 1;
-        }
-        else if self.count < self.block.n_strings {
+        } else if self.count < self.block.n_strings {
             // at pos we read a vbyte with the length of the common prefix
-            let v = VByte::parse(&self.block.encoded_strings.as_ref()[self.pos..]).expect("encoding error in self-managed data");
+            let v = VByte::parse(&self.block.encoded_strings.as_ref()[self.pos..])
+                .expect("encoding error in self-managed data");
             self.string.truncate(v.unpack() as usize);
             self.pos += v.len();
 
             // next up is the suffix, again as a nul-terminated string.
-            let postfix_end = self.pos + self.block.encoded_strings.as_ref()[self.pos..].iter().position(|&b|b==0).unwrap();
+            let postfix_end = self.pos
+                + self.block.encoded_strings.as_ref()[self.pos..]
+                    .iter()
+                    .position(|&b| b == 0)
+                    .unwrap();
 
-            self.string.extend_from_slice(&self.block.encoded_strings.as_ref()[self.pos..postfix_end]);
+            self.string
+                .extend_from_slice(&self.block.encoded_strings.as_ref()[self.pos..postfix_end]);
 
             self.pos = postfix_end + 1;
             self.count += 1;
-        }
-        else {
+        } else {
             return None;
         }
 
@@ -132,18 +140,28 @@ impl<M:AsRef<[u8]>+Clone> Iterator for OwnedPfcBlockIterator<M> {
     }
 }
 
-
-impl<M:AsRef<[u8]>+Clone> PfcBlock<M> {
-    pub fn parse(data: M) -> Result<PfcBlock<M>,PfcError> {
-        Ok(PfcBlock { encoded_strings: data, n_strings: BLOCK_SIZE })
+impl<M: AsRef<[u8]> + Clone> PfcBlock<M> {
+    pub fn parse(data: M) -> Result<PfcBlock<M>, PfcError> {
+        Ok(PfcBlock {
+            encoded_strings: data,
+            n_strings: BLOCK_SIZE,
+        })
     }
 
-    pub fn parse_incomplete(data: M, n_strings: usize) -> Result<PfcBlock<M>,PfcError> {
-        Ok(PfcBlock { encoded_strings: data, n_strings })
+    pub fn parse_incomplete(data: M, n_strings: usize) -> Result<PfcBlock<M>, PfcError> {
+        Ok(PfcBlock {
+            encoded_strings: data,
+            n_strings,
+        })
     }
 
     pub fn head(&self) -> Vec<u8> {
-        let first_end = self.encoded_strings.as_ref().iter().position(|&b|b == 0).unwrap();
+        let first_end = self
+            .encoded_strings
+            .as_ref()
+            .iter()
+            .position(|&b| b == 0)
+            .unwrap();
         let mut v = Vec::new();
         v.extend_from_slice(&self.encoded_strings.as_ref()[..first_end]);
 
@@ -155,7 +173,7 @@ impl<M:AsRef<[u8]>+Clone> PfcBlock<M> {
             block: &self,
             count: 0,
             pos: 0,
-            string: Vec::new()
+            string: Vec::new(),
         }
     }
 
@@ -164,7 +182,7 @@ impl<M:AsRef<[u8]>+Clone> PfcBlock<M> {
             block: self,
             count: 0,
             pos: 0,
-            string: Vec::new()
+            string: Vec::new(),
         }
     }
 
@@ -184,33 +202,46 @@ impl<M:AsRef<[u8]>+Clone> PfcBlock<M> {
 }
 
 #[derive(Clone)]
-pub struct PfcDict<M:AsRef<[u8]>+Clone> {
+pub struct PfcDict<M: AsRef<[u8]> + Clone> {
     n_strings: u64,
     block_offsets: LogArray<M>,
-    blocks: M
+    blocks: M,
 }
 
-pub struct PfcDictIterator<'a,M:AsRef<[u8]>+Clone> {
+pub struct PfcDictIterator<'a, M: AsRef<[u8]> + Clone> {
     dict: &'a PfcDict<M>,
     block_index: usize,
-    block: Option<OwnedPfcBlockIterator<&'a [u8]>>
+    block: Option<OwnedPfcBlockIterator<&'a [u8]>>,
 }
 
-impl<'a,M:AsRef<[u8]>+Clone> Iterator for PfcDictIterator<'a,M> {
+impl<'a, M: AsRef<[u8]> + Clone> Iterator for PfcDictIterator<'a, M> {
     type Item = String;
 
     fn next(&mut self) -> Option<String> {
         if self.block_index >= self.dict.block_offsets.len() + 1 {
-            return None
-        }
-        else if self.block.is_none() {
-            let block_offset = if self.block_index == 0 { 0 } else { self.dict.block_offsets.entry(self.block_index-1) } as usize;
+            return None;
+        } else if self.block.is_none() {
+            let block_offset = if self.block_index == 0 {
+                0
+            } else {
+                self.dict.block_offsets.entry(self.block_index - 1)
+            } as usize;
             let remainder = self.dict.n_strings as usize - self.block_index * BLOCK_SIZE;
             if remainder >= BLOCK_SIZE {
-                self.block = Some(PfcBlock::parse(&self.dict.blocks.as_ref()[block_offset..]).unwrap().into_strings());
-            }
-            else {
-                self.block = Some(PfcBlock::parse_incomplete(&self.dict.blocks.as_ref()[block_offset..], remainder).unwrap().into_strings());
+                self.block = Some(
+                    PfcBlock::parse(&self.dict.blocks.as_ref()[block_offset..])
+                        .unwrap()
+                        .into_strings(),
+                );
+            } else {
+                self.block = Some(
+                    PfcBlock::parse_incomplete(
+                        &self.dict.blocks.as_ref()[block_offset..],
+                        remainder,
+                    )
+                    .unwrap()
+                    .into_strings(),
+                );
             }
         }
 
@@ -220,21 +251,21 @@ impl<'a,M:AsRef<[u8]>+Clone> Iterator for PfcDictIterator<'a,M> {
                 self.block = None;
                 self.next()
             }
-            Some(s) => Some(s)
+            Some(s) => Some(s),
         }
     }
 }
 
-impl<M:AsRef<[u8]>+Clone> PfcDict<M> {
-    pub fn parse(blocks: M, offsets: M) -> Result<PfcDict<M>,PfcError> {
-        let n_strings = BigEndian::read_u64(&blocks.as_ref()[blocks.as_ref().len()-8..]);
+impl<M: AsRef<[u8]> + Clone> PfcDict<M> {
+    pub fn parse(blocks: M, offsets: M) -> Result<PfcDict<M>, PfcError> {
+        let n_strings = BigEndian::read_u64(&blocks.as_ref()[blocks.as_ref().len() - 8..]);
 
         let block_offsets = LogArray::parse(offsets)?;
 
         Ok(PfcDict {
             n_strings: n_strings,
             block_offsets: block_offsets,
-            blocks: blocks
+            blocks: blocks,
         })
     }
 
@@ -268,9 +299,13 @@ impl<M:AsRef<[u8]>+Clone> PfcDict<M> {
         while min <= max {
             mid = (min + max) / 2;
 
-            let block_offset = if mid == 0 { 0 } else {self.block_offsets.entry(mid-1) as usize};
+            let block_offset = if mid == 0 {
+                0
+            } else {
+                self.block_offsets.entry(mid - 1) as usize
+            };
             let block_slice = &self.blocks.as_ref()[block_offset..]; // this is probably more than one block, but we're only interested in the first string anyway
-            let head_end = block_slice.iter().position(|&b|b==0).unwrap();
+            let head_end = block_slice.iter().position(|&b| b == 0).unwrap();
             let head_slice = &block_slice[..head_end];
 
             let head = String::from_utf8(head_slice.to_vec()).unwrap();
@@ -283,21 +318,26 @@ impl<M:AsRef<[u8]>+Clone> PfcDict<M> {
                         return None;
                     }
                     max = mid - 1;
-                },
+                }
                 Ordering::Greater => min = mid + 1,
-                Ordering::Equal => return Some((mid * BLOCK_SIZE) as u64) // what luck! turns out the string we were looking for was the block head
+                Ordering::Equal => return Some((mid * BLOCK_SIZE) as u64), // what luck! turns out the string we were looking for was the block head
             }
         }
 
         let found = max;
 
         // we found the block the string should be part of.
-        let block_start = if found == 0 { 0 } else {self.block_offsets.entry(found-1) as usize};
+        let block_start = if found == 0 {
+            0
+        } else {
+            self.block_offsets.entry(found - 1) as usize
+        };
         let remainder = self.n_strings as usize - (found * BLOCK_SIZE);
         let block = if remainder >= BLOCK_SIZE {
             PfcBlock::parse(&self.blocks.as_ref()[block_start..]).unwrap()
         } else {
-            PfcBlock::parse_incomplete(&self.blocks.as_ref()[block_start..], remainder as usize).unwrap()
+            PfcBlock::parse_incomplete(&self.blocks.as_ref()[block_start..], remainder as usize)
+                .unwrap()
         };
 
         let mut count = 0;
@@ -315,12 +355,12 @@ impl<M:AsRef<[u8]>+Clone> PfcDict<M> {
         PfcDictIterator {
             dict: &self,
             block_index: 0,
-            block: None
+            block: None,
         }
     }
 }
 
-pub struct PfcDictFileBuilder<W:tokio::io::AsyncWrite+Send> {
+pub struct PfcDictFileBuilder<W: tokio::io::AsyncWrite + Send> {
     /// the file that this builder writes the pfc blocks to
     pfc_blocks_file: W,
     /// the file that this builder writes the block offsets to
@@ -330,10 +370,10 @@ pub struct PfcDictFileBuilder<W:tokio::io::AsyncWrite+Send> {
     /// the size in bytes of the pfc data structure so far
     size: usize,
     last: Option<Vec<u8>>,
-    index: Vec<u64>
+    index: Vec<u64>,
 }
 
-impl<W:'static+tokio::io::AsyncWrite+Send> PfcDictFileBuilder<W> {
+impl<W: 'static + tokio::io::AsyncWrite + Send> PfcDictFileBuilder<W> {
     pub fn new(pfc_blocks_file: W, pfc_block_offsets_file: W) -> PfcDictFileBuilder<W> {
         PfcDictFileBuilder {
             pfc_blocks_file,
@@ -341,10 +381,13 @@ impl<W:'static+tokio::io::AsyncWrite+Send> PfcDictFileBuilder<W> {
             count: 0,
             size: 0,
             last: None,
-            index: Vec::new()
+            index: Vec::new(),
         }
     }
-    pub fn add(self, s: &str) -> impl Future<Item=(u64, PfcDictFileBuilder<W>),Error=std::io::Error>+Send {
+    pub fn add(
+        self,
+        s: &str,
+    ) -> impl Future<Item = (u64, PfcDictFileBuilder<W>), Error = std::io::Error> + Send {
         let count = self.count;
         let size = self.size;
         let mut index = self.index;
@@ -357,89 +400,112 @@ impl<W:'static+tokio::io::AsyncWrite+Send> PfcDictFileBuilder<W> {
                 index.push(size as u64);
             }
             let pfc_block_offsets_file = self.pfc_block_offsets_file;
-            future::Either::A(write_nul_terminated_bytes(self.pfc_blocks_file, bytes.clone())
-                     .and_then(move |(f, len)| future::ok(((count+1) as u64, PfcDictFileBuilder {
-                         pfc_blocks_file: f,
-                         pfc_block_offsets_file,
-                         count: count + 1,
-                         size: size + len,
-                         last: Some(bytes),
-                         index: index
-                     }))))
-        }
-        else {
+            future::Either::A(
+                write_nul_terminated_bytes(self.pfc_blocks_file, bytes.clone()).and_then(
+                    move |(f, len)| {
+                        future::ok((
+                            (count + 1) as u64,
+                            PfcDictFileBuilder {
+                                pfc_blocks_file: f,
+                                pfc_block_offsets_file,
+                                count: count + 1,
+                                size: size + len,
+                                last: Some(bytes),
+                                index: index,
+                            },
+                        ))
+                    },
+                ),
+            )
+        } else {
             let s_bytes = s.as_bytes();
             let common = find_common_prefix(&self.last.unwrap(), s_bytes);
             let postfix = s_bytes[common..].to_vec();
             let pfc_block_offsets_file = self.pfc_block_offsets_file;
-            future::Either::B(VByte::write(common as u64, self.pfc_blocks_file)
-                .and_then(move |(pfc_blocks_file,vbyte_len)| write_nul_terminated_bytes(pfc_blocks_file, postfix)
-                          .map(move |(pfc_blocks_file, slice_len)| ((count+1) as u64, PfcDictFileBuilder {
-                              pfc_blocks_file,
-                              pfc_block_offsets_file,
-                              count: count + 1,
-                              size: size + vbyte_len + slice_len,
-                              last: Some(bytes),
-                              index: index
-                          }))))
+            future::Either::B(VByte::write(common as u64, self.pfc_blocks_file).and_then(
+                move |(pfc_blocks_file, vbyte_len)| {
+                    write_nul_terminated_bytes(pfc_blocks_file, postfix).map(
+                        move |(pfc_blocks_file, slice_len)| {
+                            (
+                                (count + 1) as u64,
+                                PfcDictFileBuilder {
+                                    pfc_blocks_file,
+                                    pfc_block_offsets_file,
+                                    count: count + 1,
+                                    size: size + vbyte_len + slice_len,
+                                    last: Some(bytes),
+                                    index: index,
+                                },
+                            )
+                        },
+                    )
+                },
+            ))
         }
     }
 
-    pub fn add_all<I:'static+Iterator<Item=String>+Send>(self, it:I) -> impl Future<Item=(Vec<u64>, PfcDictFileBuilder<W>), Error=std::io::Error>+Send {
+    pub fn add_all<I: 'static + Iterator<Item = String> + Send>(
+        self,
+        it: I,
+    ) -> impl Future<Item = (Vec<u64>, PfcDictFileBuilder<W>), Error = std::io::Error> + Send {
         future::loop_fn((self, it, Vec::new()), |(builder, mut it, mut result)| {
             let next = it.next();
             match next {
                 None => future::Either::A(future::ok(future::Loop::Break((result, builder)))),
-                Some(s) => future::Either::B(builder.add(&s)
-                                             .and_then(move |(r, b)| {
-                                                 result.push(r);
-                                                 future::ok(future::Loop::Continue((b, it, result)))
-                                             }))
+                Some(s) => future::Either::B(builder.add(&s).and_then(move |(r, b)| {
+                    result.push(r);
+                    future::ok(future::Loop::Continue((b, it, result)))
+                })),
             }
         })
     }
 
     /// finish the data structure
-    pub fn finalize(self) -> impl Future<Item=(),Error=std::io::Error> {
-        let width = if self.index.len() == 0 { 1 } else {64-self.index[self.index.len()-1].leading_zeros()};
+    pub fn finalize(self) -> impl Future<Item = (), Error = std::io::Error> {
+        let width = if self.index.len() == 0 {
+            1
+        } else {
+            64 - self.index[self.index.len() - 1].leading_zeros()
+        };
         let builder = LogArrayFileBuilder::new(self.pfc_block_offsets_file, width as u8);
         let count = self.count;
 
-        let write_offsets = builder.push_all(futures::stream::iter_ok(self.index))
-            .and_then(|b|b.finalize());
+        let write_offsets = builder
+            .push_all(futures::stream::iter_ok(self.index))
+            .and_then(|b| b.finalize());
 
         let finalize_blocks = write_padding(self.pfc_blocks_file, self.size, 8)
             .and_then(move |(w, _n_pad)| {
-                let mut bytes = vec![0;8];
+                let mut bytes = vec![0; 8];
                 BigEndian::write_u64(&mut bytes, count as u64);
                 tokio::io::write_all(w, bytes)
             })
-            .and_then(|(w,_)| tokio::io::flush(w));
+            .and_then(|(w, _)| tokio::io::flush(w));
 
-        write_offsets.join(finalize_blocks)
-            .map(|_|())
+        write_offsets.join(finalize_blocks).map(|_| ())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::*;
     use crate::storage::memory::*;
+    use crate::storage::*;
 
     #[test]
     fn can_create_pfc_dict_small() {
-        let contents = vec!["aaaaa",
-                            "aabbb",
-                            "ccccc"];
+        let contents = vec!["aaaaa", "aabbb", "ccccc"];
         let blocks = MemoryBackedStore::new();
         let offsets = MemoryBackedStore::new();
         let builder = PfcDictFileBuilder::new(blocks.open_write(), offsets.open_write());
-        builder.add_all(contents.into_iter().map(|s|s.to_string()))
-            .and_then(|(_,b)|b.finalize())
-            .wait().unwrap();
+        builder
+            .add_all(contents.into_iter().map(|s| s.to_string()))
+            .and_then(|(_, b)| b.finalize())
+            .wait()
+            .unwrap();
 
-        let p = PfcDict::parse(blocks.map().wait().unwrap(), offsets.map().wait().unwrap()).unwrap();
+        let p =
+            PfcDict::parse(blocks.map().wait().unwrap(), offsets.map().wait().unwrap()).unwrap();
 
         assert_eq!(Some("aaaaa".to_string()), p.get(0));
         assert_eq!(Some("aabbb".to_string()), p.get(1));
@@ -456,27 +522,31 @@ mod tests {
 
     #[test]
     fn can_create_pfc_dict_large() {
-        let contents = vec!["aaaaa",
-                            "aabbb",
-                            "ccccc",
-                            "ddddd asfdl;kfasf opxcvucvkhf asfopihvpvoihfasdfjv;xivh",
-                            "deasdfvv apobk,naf;libpoiujsafd",
-                            "deasdfvv apobk,x",
-                            "ee",
-                            "eee",
-                            "eeee",
-                            "great scott"
+        let contents = vec![
+            "aaaaa",
+            "aabbb",
+            "ccccc",
+            "ddddd asfdl;kfasf opxcvucvkhf asfopihvpvoihfasdfjv;xivh",
+            "deasdfvv apobk,naf;libpoiujsafd",
+            "deasdfvv apobk,x",
+            "ee",
+            "eee",
+            "eeee",
+            "great scott",
         ];
 
         let blocks = MemoryBackedStore::new();
         let offsets = MemoryBackedStore::new();
         let builder = PfcDictFileBuilder::new(blocks.open_write(), offsets.open_write());
 
-        builder.add_all(contents.into_iter().map(|s|s.to_string()))
-            .and_then(|(_,b)|b.finalize())
-            .wait().unwrap();
+        builder
+            .add_all(contents.into_iter().map(|s| s.to_string()))
+            .and_then(|(_, b)| b.finalize())
+            .wait()
+            .unwrap();
 
-        let p = PfcDict::parse(blocks.map().wait().unwrap(), offsets.map().wait().unwrap()).unwrap();
+        let p =
+            PfcDict::parse(blocks.map().wait().unwrap(), offsets.map().wait().unwrap()).unwrap();
 
         assert_eq!(Some("aaaaa".to_string()), p.get(0));
         assert_eq!(Some("aabbb".to_string()), p.get(1));
@@ -506,18 +576,21 @@ mod tests {
             "faadsafdfaf sdfasdf",
             "frumps framps fremps",
             "gahh",
-            "hai hai hai"
-            ];
+            "hai hai hai",
+        ];
 
         let blocks = MemoryBackedStore::new();
         let offsets = MemoryBackedStore::new();
         let builder = PfcDictFileBuilder::new(blocks.open_write(), offsets.open_write());
 
-        builder.add_all(contents.into_iter().map(|s|s.to_string()))
-            .and_then(|(_,b)|b.finalize())
-            .wait().unwrap();
+        builder
+            .add_all(contents.into_iter().map(|s| s.to_string()))
+            .and_then(|(_, b)| b.finalize())
+            .wait()
+            .unwrap();
 
-        let dict = PfcDict::parse(blocks.map().wait().unwrap(), offsets.map().wait().unwrap()).unwrap();
+        let dict =
+            PfcDict::parse(blocks.map().wait().unwrap(), offsets.map().wait().unwrap()).unwrap();
 
         assert_eq!(Some(0), dict.id("aaaaa"));
         assert_eq!(Some(2), dict.id("arf"));
@@ -551,18 +624,21 @@ mod tests {
             "faadsafdfaf sdfasdf",
             "frumps framps fremps",
             "gahh",
-            "hai hai hai"
-            ];
+            "hai hai hai",
+        ];
 
         let blocks = MemoryBackedStore::new();
         let offsets = MemoryBackedStore::new();
         let builder = PfcDictFileBuilder::new(blocks.open_write(), offsets.open_write());
 
-        builder.add_all(contents.clone().into_iter().map(|s|s.to_string()))
-            .and_then(|(_,b)|b.finalize())
-            .wait().unwrap();
+        builder
+            .add_all(contents.clone().into_iter().map(|s| s.to_string()))
+            .and_then(|(_, b)| b.finalize())
+            .wait()
+            .unwrap();
 
-        let dict = PfcDict::parse(blocks.map().wait().unwrap(), offsets.map().wait().unwrap()).unwrap();
+        let dict =
+            PfcDict::parse(blocks.map().wait().unwrap(), offsets.map().wait().unwrap()).unwrap();
 
         let result: Vec<String> = dict.strings().collect();
         assert_eq!(contents, result);

--- a/src/structure/pfc.rs
+++ b/src/structure/pfc.rs
@@ -10,6 +10,7 @@ use futures::prelude::*;
 use std::cmp::{Ord, Ordering};
 use std::error::Error;
 use std::fmt::Display;
+use tokio::io::AsyncWrite;
 
 #[derive(Debug)]
 pub enum PfcError {
@@ -44,21 +45,21 @@ impl Into<std::io::Error> for PfcError {
 }
 
 #[derive(Clone)]
-pub struct PfcBlock<M: AsRef<[u8]> + Clone> {
+pub struct PfcBlock<M> {
     encoded_strings: M,
     n_strings: usize,
 }
 
 const BLOCK_SIZE: usize = 8;
 
-pub struct PfcBlockIterator<'a, M: AsRef<[u8]> + Clone> {
+pub struct PfcBlockIterator<'a, M> {
     block: &'a PfcBlock<M>,
     count: usize,
     pos: usize,
     string: Vec<u8>,
 }
 
-impl<'a, M: AsRef<[u8]> + Clone> Iterator for PfcBlockIterator<'a, M> {
+impl<'a, M: AsRef<[u8]>> Iterator for PfcBlockIterator<'a, M> {
     type Item = String;
 
     fn next(&mut self) -> Option<String> {
@@ -96,14 +97,14 @@ impl<'a, M: AsRef<[u8]> + Clone> Iterator for PfcBlockIterator<'a, M> {
 }
 
 // the owned version is pretty much equivalent. There should be a way to make this one implementation with generics but I haven't figured out how!
-pub struct OwnedPfcBlockIterator<M: AsRef<[u8]> + Clone> {
+pub struct OwnedPfcBlockIterator<M> {
     block: PfcBlock<M>,
     count: usize,
     pos: usize,
     string: Vec<u8>,
 }
 
-impl<M: AsRef<[u8]> + Clone> Iterator for OwnedPfcBlockIterator<M> {
+impl<M: AsRef<[u8]>> Iterator for OwnedPfcBlockIterator<M> {
     type Item = String;
 
     fn next(&mut self) -> Option<String> {
@@ -140,7 +141,7 @@ impl<M: AsRef<[u8]> + Clone> Iterator for OwnedPfcBlockIterator<M> {
     }
 }
 
-impl<M: AsRef<[u8]> + Clone> PfcBlock<M> {
+impl<M> PfcBlock<M> {
     pub fn parse(data: M) -> Result<PfcBlock<M>, PfcError> {
         Ok(PfcBlock {
             encoded_strings: data,
@@ -155,7 +156,10 @@ impl<M: AsRef<[u8]> + Clone> PfcBlock<M> {
         })
     }
 
-    pub fn head(&self) -> Vec<u8> {
+    pub fn head(&self) -> Vec<u8>
+    where
+        M: AsRef<[u8]>,
+    {
         let first_end = self
             .encoded_strings
             .as_ref()
@@ -186,7 +190,10 @@ impl<M: AsRef<[u8]> + Clone> PfcBlock<M> {
         }
     }
 
-    pub fn get(&self, index: usize) -> Option<String> {
+    pub fn get(&self, index: usize) -> Option<String>
+    where
+        M: AsRef<[u8]>,
+    {
         if index < self.n_strings {
             self.strings().nth(index)
         } else {
@@ -194,27 +201,29 @@ impl<M: AsRef<[u8]> + Clone> PfcBlock<M> {
         }
     }
 
-    pub fn len(&self) -> usize {
+    pub fn len(&self) -> usize
+    where
+        M: AsRef<[u8]>,
+    {
         let vbyte_len = VByte::required_len(self.encoded_strings.as_ref().len() as u64);
-
         vbyte_len + self.encoded_strings.as_ref().len()
     }
 }
 
 #[derive(Clone)]
-pub struct PfcDict<M: AsRef<[u8]> + Clone> {
+pub struct PfcDict<M> {
     n_strings: u64,
     block_offsets: LogArray<M>,
     blocks: M,
 }
 
-pub struct PfcDictIterator<'a, M: AsRef<[u8]> + Clone> {
+pub struct PfcDictIterator<'a, M> {
     dict: &'a PfcDict<M>,
     block_index: usize,
     block: Option<OwnedPfcBlockIterator<&'a [u8]>>,
 }
 
-impl<'a, M: AsRef<[u8]> + Clone> Iterator for PfcDictIterator<'a, M> {
+impl<'a, M: AsRef<[u8]>> Iterator for PfcDictIterator<'a, M> {
     type Item = String;
 
     fn next(&mut self) -> Option<String> {
@@ -256,8 +265,11 @@ impl<'a, M: AsRef<[u8]> + Clone> Iterator for PfcDictIterator<'a, M> {
     }
 }
 
-impl<M: AsRef<[u8]> + Clone> PfcDict<M> {
-    pub fn parse(blocks: M, offsets: M) -> Result<PfcDict<M>, PfcError> {
+impl<M> PfcDict<M> {
+    pub fn parse(blocks: M, offsets: M) -> Result<PfcDict<M>, PfcError>
+    where
+        M: AsRef<[u8]>,
+    {
         let n_strings = BigEndian::read_u64(&blocks.as_ref()[blocks.as_ref().len() - 8..]);
 
         let block_offsets = LogArray::parse(offsets)?;
@@ -273,7 +285,10 @@ impl<M: AsRef<[u8]> + Clone> PfcDict<M> {
         self.n_strings as usize
     }
 
-    pub fn get(&self, ix: usize) -> Option<String> {
+    pub fn get(&self, ix: usize) -> Option<String>
+    where
+        M: AsRef<[u8]>,
+    {
         if (ix as u64) < self.n_strings {
             let block_index = ix / BLOCK_SIZE;
             let block_offset = if block_index == 0 {
@@ -290,7 +305,10 @@ impl<M: AsRef<[u8]> + Clone> PfcDict<M> {
         }
     }
 
-    pub fn id(&self, s: &str) -> Option<u64> {
+    pub fn id(&self, s: &str) -> Option<u64>
+    where
+        M: AsRef<[u8]>,
+    {
         // let's binary search
         let mut min = 0;
         let mut max = self.block_offsets.len();
@@ -360,7 +378,7 @@ impl<M: AsRef<[u8]> + Clone> PfcDict<M> {
     }
 }
 
-pub struct PfcDictFileBuilder<W: tokio::io::AsyncWrite + Send> {
+pub struct PfcDictFileBuilder<W> {
     /// the file that this builder writes the pfc blocks to
     pfc_blocks_file: W,
     /// the file that this builder writes the block offsets to
@@ -373,7 +391,7 @@ pub struct PfcDictFileBuilder<W: tokio::io::AsyncWrite + Send> {
     index: Vec<u64>,
 }
 
-impl<W: 'static + tokio::io::AsyncWrite + Send> PfcDictFileBuilder<W> {
+impl<W> PfcDictFileBuilder<W> {
     pub fn new(pfc_blocks_file: W, pfc_block_offsets_file: W) -> PfcDictFileBuilder<W> {
         PfcDictFileBuilder {
             pfc_blocks_file,
@@ -384,6 +402,9 @@ impl<W: 'static + tokio::io::AsyncWrite + Send> PfcDictFileBuilder<W> {
             index: Vec::new(),
         }
     }
+}
+
+impl<W: 'static + AsyncWrite + Send> PfcDictFileBuilder<W> {
     pub fn add(
         self,
         s: &str,

--- a/src/structure/util.rs
+++ b/src/structure/util.rs
@@ -1,5 +1,6 @@
 use byteorder::{BigEndian, ByteOrder};
 use futures::prelude::*;
+use tokio::io::AsyncWrite;
 
 pub fn find_common_prefix(b1: &[u8], b2: &[u8]) -> usize {
     let mut common = 0;
@@ -14,7 +15,7 @@ pub fn find_common_prefix(b1: &[u8], b2: &[u8]) -> usize {
     common
 }
 
-pub fn write_nul_terminated_bytes<W: tokio::io::AsyncWrite + Send>(
+pub fn write_nul_terminated_bytes<W: AsyncWrite + Send>(
     w: W,
     bytes: Vec<u8>,
 ) -> impl Future<Item = (W, usize), Error = std::io::Error> {
@@ -24,7 +25,7 @@ pub fn write_nul_terminated_bytes<W: tokio::io::AsyncWrite + Send>(
     })
 }
 
-pub fn write_padding<W: tokio::io::AsyncWrite + Send>(
+pub fn write_padding<W: AsyncWrite + Send>(
     w: W,
     current_pos: usize,
     width: u8,
@@ -34,7 +35,7 @@ pub fn write_padding<W: tokio::io::AsyncWrite + Send>(
         .map(|(w, slice)| (w, slice.len()))
 }
 
-pub fn write_u64<W: tokio::io::AsyncWrite + Send>(
+pub fn write_u64<W: AsyncWrite + Send>(
     w: W,
     num: u64,
 ) -> impl Future<Item = W, Error = std::io::Error> {

--- a/src/structure/util.rs
+++ b/src/structure/util.rs
@@ -1,13 +1,12 @@
+use byteorder::{BigEndian, ByteOrder};
 use futures::prelude::*;
-use byteorder::{ByteOrder,BigEndian};
 
 pub fn find_common_prefix(b1: &[u8], b2: &[u8]) -> usize {
     let mut common = 0;
     while common < b1.len() && common < b2.len() {
         if b1[common] == b2[common] {
             common += 1;
-        }
-        else {
+        } else {
             break;
         }
     }
@@ -15,25 +14,32 @@ pub fn find_common_prefix(b1: &[u8], b2: &[u8]) -> usize {
     common
 }
 
-pub fn write_nul_terminated_bytes<W:tokio::io::AsyncWrite+Send>(w:W, bytes: Vec<u8>) -> impl Future<Item=(W, usize), Error=std::io::Error> {
-    tokio::io::write_all(w, bytes)
-        .and_then(|(w, slice)| {
-            let count = slice.len() + 1;
-            tokio::io::write_all(w, [0])
-                .map(move |(w, _)| (w, count))
-        })
+pub fn write_nul_terminated_bytes<W: tokio::io::AsyncWrite + Send>(
+    w: W,
+    bytes: Vec<u8>,
+) -> impl Future<Item = (W, usize), Error = std::io::Error> {
+    tokio::io::write_all(w, bytes).and_then(|(w, slice)| {
+        let count = slice.len() + 1;
+        tokio::io::write_all(w, [0]).map(move |(w, _)| (w, count))
+    })
 }
 
-pub fn write_padding<W:tokio::io::AsyncWrite+Send>(w:W, current_pos: usize, width: u8) -> impl Future<Item=(W, usize), Error=std::io::Error> {
+pub fn write_padding<W: tokio::io::AsyncWrite + Send>(
+    w: W,
+    current_pos: usize,
+    width: u8,
+) -> impl Future<Item = (W, usize), Error = std::io::Error> {
     let required_padding = (width as usize - current_pos % width as usize) % width as usize;
-    tokio::io::write_all(w, vec![0;required_padding]) // there has to be a better way
+    tokio::io::write_all(w, vec![0; required_padding]) // there has to be a better way
         .map(|(w, slice)| (w, slice.len()))
 }
 
-pub fn write_u64<W:tokio::io::AsyncWrite+Send>(w: W, num: u64) -> impl Future<Item=W, Error=std::io::Error> {
-    let mut v = vec![0u8;8];
+pub fn write_u64<W: tokio::io::AsyncWrite + Send>(
+    w: W,
+    num: u64,
+) -> impl Future<Item = W, Error = std::io::Error> {
+    let mut v = vec![0u8; 8];
     BigEndian::write_u64(&mut v, num);
 
-    tokio::io::write_all(w, v)
-        .map(|(w,_)| w)
+    tokio::io::write_all(w, v).map(|(w, _)| w)
 }

--- a/src/structure/vbyte.rs
+++ b/src/structure/vbyte.rs
@@ -1,10 +1,12 @@
 //! A compressed integer implementation.
-use std::io::Write;
+
 use futures::prelude::*;
-use tokio::io::{write_all,AsyncWrite};
-use std::fmt::{self,Debug};
+use std::fmt::{self, Debug};
+use std::io::Write;
+use tokio::io::{write_all, AsyncWrite};
+
 pub struct VByte<'a> {
-    packed: &'a [u8]
+    packed: &'a [u8],
 }
 
 #[derive(Debug)]
@@ -18,13 +20,15 @@ impl<'a> Debug for VByte<'a> {
 }
 
 impl<'a> VByte<'a> {
-    pub fn parse(bytes: &[u8]) -> Result<VByte,VByteError> {
+    pub fn parse(bytes: &[u8]) -> Result<VByte, VByteError> {
         let pos = bytes.iter().position(|&b| b & 0x80 != 0).unwrap();
         // todo error checking, limit to certain amount of bytes that fit in u64
-        Ok(VByte { packed: &bytes[..pos+1] })
+        Ok(VByte {
+            packed: &bytes[..pos + 1],
+        })
     }
 
-    pub fn insert(mut num: u64, slice: &mut [u8]) -> Result<VByte,VByteError> {
+    pub fn insert(mut num: u64, slice: &mut [u8]) -> Result<VByte, VByteError> {
         let num_bits = 64 - num.leading_zeros();
         let mut remainder = num_bits;
         let mut index = 0;
@@ -38,12 +42,16 @@ impl<'a> VByte<'a> {
 
         slice[index] = (0x80 | num) as u8;
 
-        Ok(VByte { packed: &slice[..index+1] })
+        Ok(VByte {
+            packed: &slice[..index + 1],
+        })
     }
 
-    pub fn write_sync<W>(num: u64, dest: &mut W) -> Result<(),std::io::Error>
-    where W: 'static+Write {
-        let mut buf = [0;10];
+    pub fn write_sync<W>(num: u64, dest: &mut W) -> Result<(), std::io::Error>
+    where
+        W: 'static + Write,
+    {
+        let mut buf = [0; 10];
         let trunc_len = {
             let v = VByte::insert(num, &mut buf).unwrap();
             v.len()
@@ -52,23 +60,28 @@ impl<'a> VByte<'a> {
         dest.write_all(&buf[..trunc_len])
     }
 
-    pub fn write<A>(num: u64, dest: A) -> Box<dyn Future<Item=(A,usize),Error=tokio::io::Error>+Send>
-    where A: 'static+AsyncWrite+Send {
-        let mut buf = vec![0;10];
+    pub fn write<A>(
+        num: u64,
+        dest: A,
+    ) -> Box<dyn Future<Item = (A, usize), Error = tokio::io::Error> + Send>
+    where
+        A: 'static + AsyncWrite + Send,
+    {
+        let mut buf = vec![0; 10];
         let trunc_len = {
             let v = VByte::insert(num, &mut buf).unwrap();
             v.len()
         };
         buf.truncate(trunc_len);
 
-        Box::new(write_all(dest, buf).map(move |(d,_)|(d,trunc_len)))
+        Box::new(write_all(dest, buf).map(move |(d, _)| (d, trunc_len)))
     }
 
     pub fn unpack(&self) -> u64 {
-        let mut result : u64 = 0;
-        let mut shift : u64 = 0;
+        let mut result: u64 = 0;
+        let mut shift: u64 = 0;
         for b in self.packed {
-            result |= (((b)&0x7f as u8) as u64) << shift;
+            result |= (((b) & 0x7f as u8) as u64) << shift;
             if b & 0x80 != 0 {
                 break;
             }
@@ -87,7 +100,6 @@ impl<'a> VByte<'a> {
         let used_bits = 64 - num.leading_zeros();
         (used_bits as usize + 6) / 7
     }
-
 }
 
 #[cfg(test)]
@@ -98,7 +110,7 @@ mod tests {
     #[test]
     fn insert_then_unpack_returns_same_small() {
         let num = 42;
-        let mut vec = vec![0;10];
+        let mut vec = vec![0; 10];
 
         let vbyte = VByte::insert(num, &mut vec).unwrap();
         assert_eq!(42, vbyte.unpack());
@@ -107,7 +119,7 @@ mod tests {
     #[test]
     fn insert_then_unpack_returns_same_medium() {
         let num = 424;
-        let mut vec = vec![0;10];
+        let mut vec = vec![0; 10];
 
         let vbyte = VByte::insert(num, &mut vec).unwrap();
         assert_eq!(424, vbyte.unpack());
@@ -116,7 +128,7 @@ mod tests {
     #[test]
     fn insert_then_unpack_returns_same_large() {
         let num = 42424242;
-        let mut vec = vec![0;10];
+        let mut vec = vec![0; 10];
 
         let vbyte = VByte::insert(num, &mut vec).unwrap();
         assert_eq!(42424242, vbyte.unpack());
@@ -124,21 +136,21 @@ mod tests {
 
     #[test]
     fn parse_then_unpack_returns_expected_small() {
-        let vec: Vec<u8> = vec![0x80|42];
+        let vec: Vec<u8> = vec![0x80 | 42];
         let vbyte = VByte::parse(&vec).unwrap();
         assert_eq!(42, vbyte.unpack());
     }
 
     #[test]
     fn parse_then_unpack_returns_expected_medium() {
-        let vec: Vec<u8> = vec![0x28,0x80|3];
+        let vec: Vec<u8> = vec![0x28, 0x80 | 3];
         let vbyte = VByte::parse(&vec).unwrap();
         assert_eq!(424, vbyte.unpack());
     }
 
     #[test]
     fn parse_then_unpack_returns_expected_large() {
-        let vec: Vec<u8> = vec![0x32,0x2f,0x1d,0x80|0x14];
+        let vec: Vec<u8> = vec![0x32, 0x2f, 0x1d, 0x80 | 0x14];
         let vbyte = VByte::parse(&vec).unwrap();
         assert_eq!(42424242, vbyte.unpack());
     }
@@ -146,11 +158,11 @@ mod tests {
     #[test]
     fn write_then_parse_returns_expected() {
         let num = 42424242;
-        let mut vec = vec![0;10];
+        let mut vec = vec![0; 10];
         let cursor = Cursor::new(vec);
 
         let fut = VByte::write(num, cursor);
-        let (c,_length) = fut.wait().unwrap();
+        let (c, _length) = fut.wait().unwrap();
 
         vec = c.into_inner();
 

--- a/src/structure/wavelettree.rs
+++ b/src/structure/wavelettree.rs
@@ -16,7 +16,7 @@ use tokio::prelude::*;
 /// rounded up to make it an integer. Since we're encoding u64 values,
 /// the number of layers can never be larger than 64.
 #[derive(Clone)]
-pub struct WaveletTree<M: AsRef<[u8]> + Clone> {
+pub struct WaveletTree<M> {
     bits: BitIndex<M>,
     num_layers: u8,
 }
@@ -27,14 +27,14 @@ pub struct WaveletTree<M: AsRef<[u8]> + Clone> {
 /// positions out of a wavelet tree, allowing for quick iteration over
 /// all positions for a given entry.
 #[derive(Clone)]
-pub struct WaveletLookup<M: AsRef<[u8]> + Clone> {
+pub struct WaveletLookup<M> {
     /// the entry this lookup was created for.
     pub entry: u64,
     tree: WaveletTree<M>,
     slices: Vec<(bool, u64, u64)>,
 }
 
-impl<M: AsRef<[u8]> + Clone> WaveletLookup<M> {
+impl<M: AsRef<[u8]>> WaveletLookup<M> {
     /// Returns the amount of positions found in this lookup.
     pub fn len(&self) -> usize {
         let (b, start, end) = *self.slices.last().unwrap();
@@ -77,13 +77,16 @@ impl<M: AsRef<[u8]> + Clone> WaveletLookup<M> {
     }
 
     /// Returns an Iterator over all positions for the entry of this lookup
-    pub fn iter(&self) -> impl Iterator<Item = u64> {
+    pub fn iter(&self) -> impl Iterator<Item = u64>
+    where
+        M: Clone,
+    {
         let cloned = self.clone();
         (0..self.len()).map(move |i| cloned.entry(i))
     }
 }
 
-impl<M: AsRef<[u8]> + Clone> WaveletTree<M> {
+impl<M> WaveletTree<M> {
     /// Construct a wavelet tree from a bitindex and a layer count.
     pub fn from_parts(bits: BitIndex<M>, num_layers: u8) -> WaveletTree<M> {
         if num_layers != 0 && bits.len() % num_layers as usize != 0 {
@@ -108,13 +111,19 @@ impl<M: AsRef<[u8]> + Clone> WaveletTree<M> {
     }
 
     /// Decode the wavelet tree to the original u64 sequence. This returns an iterator.
-    pub fn decode(&self) -> impl Iterator<Item = u64> {
+    pub fn decode(&self) -> impl Iterator<Item = u64>
+    where
+        M: AsRef<[u8]> + Clone,
+    {
         let owned = self.clone();
         (0..self.len()).map(move |i| owned.decode_one(i))
     }
 
     /// Decode a single position of the original u64 sequence.
-    pub fn decode_one(&self, index: usize) -> u64 {
+    pub fn decode_one(&self, index: usize) -> u64
+    where
+        M: AsRef<[u8]>,
+    {
         let len = self.len() as u64;
         let mut offset = index as u64;
         let mut alphabet_start = 0;
@@ -155,7 +164,10 @@ impl<M: AsRef<[u8]> + Clone> WaveletTree<M> {
     }
 
     /// Lookup the given entry. This returns a `WaveletLookup` which can then be used to find all positions.
-    pub fn lookup(&self, entry: u64) -> Option<WaveletLookup<M>> {
+    pub fn lookup(&self, entry: u64) -> Option<WaveletLookup<M>>
+    where
+        M: AsRef<[u8]> + Clone,
+    {
         let width = self.len() as u64;
         let mut slices = Vec::with_capacity(self.num_layers as usize);
         let mut alphabet_start = 0;
@@ -193,14 +205,17 @@ impl<M: AsRef<[u8]> + Clone> WaveletTree<M> {
     }
 
     /// Lookup the given entry. This returns a single result, even if there's multiple.
-    pub fn lookup_one(&self, entry: u64) -> Option<u64> {
+    pub fn lookup_one(&self, entry: u64) -> Option<u64>
+    where
+        M: AsRef<[u8]> + Clone,
+    {
         self.lookup(entry).map(|l| l.entry(0))
     }
 }
 
 fn build_wavelet_fragment<
     S: Stream<Item = u64, Error = std::io::Error> + Send,
-    W: AsyncWrite + Send,
+    W: 'static + AsyncWrite + Send,
 >(
     stream: S,
     write: BitArrayFileBuilder<W>,
@@ -266,7 +281,7 @@ pub fn build_wavelet_tree_from_stream<
 
 /// Build a wavelet tree from a file storing a logarray.
 pub fn build_wavelet_tree_from_logarray<
-    FLoad: 'static + FileLoad + Clone,
+    FLoad: 'static + FileLoad,
     F: 'static + FileLoad + FileStore,
 >(
     source: FLoad,


### PR DESCRIPTION
There are two related changes here. Neither one involves a change to the function of the code. Both are localized to the `src/structure` directory to reduce the number of changes to review.

The first change is to run `rustfmt` over all of the source files in the directory. This is mostly a whitespace change.

The second is reduce the usage of trait bounds to only where they are needed. The main changes were:
* In general, the `struct`s did not need trait bounds. I removed all except one, which was necessary.
* There were a large number of `Clone` bounds that were not needed. I removed all except the necessary ones, which I attached to functions instead of the implementation.
* I reduced the number of `AsRef<[u8]>` bounds to make it clear which functions used it and which did not.