### PR TITLE
Use a more efficient bit iterator

### DIFF
--- a/src/structure/bitarray.rs
+++ b/src/structure/bitarray.rs
@@ -1,6 +1,7 @@
 //! Logic for storing, loading and using arrays of bits.
 use super::util::*;
 use crate::storage::*;
+use crate::structure::bititer::BitIter;
 use byteorder::{BigEndian, ByteOrder};
 use bytes::BytesMut;
 use futures::prelude::*;
@@ -171,23 +172,12 @@ fn bitarray_count_from_file<F: FileLoad>(f: F) -> impl Future<Item = u64, Error 
         .map(|(_, buf)| BigEndian::read_u64(&buf))
 }
 
-fn block_bits(block: u64) -> Vec<bool> {
-    let mut mask = 0x8000000000000000;
-    let mut result = Vec::with_capacity(64);
-    for _ in 0..64 {
-        result.push(block & mask != 0);
-        mask >>= 1;
-    }
-
-    result
-}
-
 pub fn bitarray_stream_bits<F: FileLoad>(f: F) -> impl Stream<Item = bool, Error = std::io::Error> {
     bitarray_count_from_file(f.clone())
         .into_stream()
         .map(move |count| {
             bitarray_stream_blocks(f.open_read())
-                .map(|block| stream::iter_ok(block_bits(block).into_iter()))
+                .map(|block| stream::iter_ok(BitIter::new(block)))
                 .flatten()
                 .take(count)
         })

--- a/src/structure/bititer.rs
+++ b/src/structure/bititer.rs
@@ -1,0 +1,73 @@
+//! Bit iterator for `u64`
+
+/// An efficient bit iterator from msb to lsb for `u64`.
+///
+/// For each bit, starting from the msb and ending with the lsb, if the bit is `1`, the iterator
+/// produces `true`, and if the bit is `0`, the iterator produces `false`.
+pub(crate) struct BitIter {
+    /// The value whose bits are iterated through.
+    value: u64,
+
+    /// A bit mask used to select a single bit for every iteration.
+    ///
+    /// Loop invariant: The mask will always have at most 1 bit set.
+    mask: u64,
+}
+
+impl BitIter {
+    /// Create a `BitIter` from a `u64`.
+    pub(crate) const fn new(value: u64) -> Self {
+        BitIter {
+            value,
+            // Initialize the mask to select the msb.
+            mask: 0x8000_0000_0000_0000,
+        }
+    }
+}
+
+impl Iterator for BitIter {
+    type Item = bool;
+
+    fn next(&mut self) -> Option<bool> {
+        let mask = self.mask;
+        // Check if the masked bit has been shifted past the lsb.
+        if mask != 0 {
+            // We're not done, yet. Shift the mask for the next iteration and return the currently
+            // selected bit as a `bool`.
+            self.mask >>= 1;
+            // `true` if the bit selected by the mask is `1`, `false` if `0`.
+            Some(self.value & mask != 0)
+        } else {
+            // We're done iterating.
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    pub fn zero() {
+        for b in BitIter::new(0) {
+            assert!(!b);
+        }
+    }
+
+    #[test]
+    pub fn max() {
+        for b in BitIter::new(u64::max_value()) {
+            assert!(b);
+        }
+    }
+
+    #[test]
+    pub fn alternating() {
+        let mut expected = true;
+        for b in BitIter::new(0xaaaa_aaaa_aaaa_aaaa) {
+            assert_eq!(expected, b);
+            expected = !expected;
+        }
+    }
+}

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -5,6 +5,7 @@
 pub mod adjacencylist;
 pub mod bitarray;
 pub mod bitindex;
+pub mod bititer;
 pub mod logarray;
 pub mod pfc;
 mod util;


### PR DESCRIPTION
This is a simple change that avoids creating a `Vec<bool>` of capacity 64 when iterating over the bits of a `u64`.