### PR TITLE
src/structure/util.rs: minor cleanups

### DIFF
--- a/src/structure/bitarray.rs
+++ b/src/structure/bitarray.rs
@@ -1,5 +1,5 @@
 //! Logic for storing, loading and using arrays of bits.
-use super::util::*;
+use super::util;
 use crate::storage::*;
 use byteorder::{BigEndian, ByteOrder};
 use bytes::BytesMut;
@@ -112,8 +112,7 @@ where
     }
 
     fn pad(self) -> impl Future<Item = W, Error = std::io::Error> {
-        write_padding(self.bit_output, (self.count as usize + 7) / 8, 8)
-            .map(|(bit_output, _)| bit_output)
+        util::write_padding(self.bit_output, (self.count as usize + 7) / 8, 8)
     }
 
     pub fn finalize(self) -> impl Future<Item = W, Error = std::io::Error> {
@@ -128,7 +127,7 @@ where
 
         flush_current
             .and_then(|b| b.pad())
-            .and_then(move |w| write_u64(w, count))
+            .and_then(move |w| util::write_u64(w, count))
             .and_then(|w| tokio::io::flush(w))
     }
 


### PR DESCRIPTION
* Use `u64::to_be_bytes` instead of `BigEndian::write_u64`: avoids
  unnecessary `Vec` creation.
* Prepend `util::` to make it easier to find the source of those
  functions and to distinguish them from similar found in `tokio:io`.