### PR TITLE
bugfix: invalidate full parent chain in register_rollup to prevent cache accumulation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminus-store"
-version = "0.21.5"
+version = "0.21.6"
 authors = ["Matthijs van Otterdijk <matthijs@datachemist.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/storage/cache.rs
+++ b/src/storage/cache.rs
@@ -12,6 +12,12 @@ pub trait LayerCache: 'static + Send + Sync {
     fn cache_layer(&self, layer: Arc<InternalLayer>);
 
     fn invalidate(&self, name: [u32; 5]);
+
+    /// Remove stale entries from the cache. Returns number of entries removed.
+    /// Default implementation does nothing.
+    fn cleanup_stale_entries(&self) -> usize {
+        0
+    }
 }
 
 pub struct NoCache;
@@ -32,7 +38,13 @@ lazy_static! {
 
 // locking isn't really ideal but the lock window will be relatively small so it shouldn't hurt performance too much except on heavy updates.
 // ideally we should be using some concurrent hashmap implementation instead.
-// furthermore, there should be some logic to remove stale entries, like a periodic pass. right now, there isn't.
+
+/// Threshold for automatic cleanup: when cache size exceeds this, trigger cleanup on next cache_layer call.
+const CACHE_CLEANUP_THRESHOLD: usize = 100;
+
+/// Only cleanup if dead entries exceed this percentage of total.
+const DEAD_ENTRY_PERCENTAGE_THRESHOLD: usize = 20;
+
 #[derive(Default)]
 pub struct LockingHashMapLayerCache {
     cache: RwLock<HashMap<[u32; 5], Weak<InternalLayer>>>,
@@ -41,6 +53,16 @@ pub struct LockingHashMapLayerCache {
 impl LockingHashMapLayerCache {
     pub fn new() -> Self {
         Default::default()
+    }
+
+    /// Remove all stale (dead) weak references from the cache.
+    /// Returns the number of entries removed.
+    pub fn cleanup_stale(&self) -> usize {
+        let mut cache = self.cache.write().expect("rwlock write should always succeed, but got poisoned");
+        let before = cache.len();
+        cache.retain(|_, weak| weak.strong_count() > 0);
+        let after = cache.len();
+        before - after
     }
 }
 
@@ -74,6 +96,20 @@ impl LayerCache for LockingHashMapLayerCache {
             .cache
             .write()
             .expect("rwlock write should always succeed");
+        
+        // Automatic cleanup: when cache exceeds threshold, check for stale entries
+        let cache_size = cache.len();
+        if cache_size >= CACHE_CLEANUP_THRESHOLD {
+            // Count dead entries
+            let dead_count = cache.values().filter(|w| w.strong_count() == 0).count();
+            let dead_percentage = (dead_count * 100) / cache_size.max(1);
+            
+            // Only cleanup if dead entries exceed threshold percentage
+            if dead_percentage >= DEAD_ENTRY_PERCENTAGE_THRESHOLD {
+                cache.retain(|_, weak| weak.strong_count() > 0);
+            }
+        }
+        
         cache.insert(layer.name(), Arc::downgrade(&layer));
     }
 
@@ -85,6 +121,10 @@ impl LayerCache for LockingHashMapLayerCache {
             .expect("rwlock read should always succeed");
 
         cache.remove(&name);
+    }
+
+    fn cleanup_stale_entries(&self) -> usize {
+        self.cleanup_stale()
     }
 }
 
@@ -104,6 +144,11 @@ impl CachedLayerStore {
 
     pub fn invalidate(&self, name: [u32; 5]) {
         self.cache.invalidate(name);
+    }
+
+    /// Remove stale entries from the cache. Returns number of entries removed.
+    pub fn cleanup_stale_entries(&self) -> usize {
+        self.cache.cleanup_stale_entries()
     }
 }
 
@@ -305,8 +350,20 @@ impl LayerStore for CachedLayerStore {
     async fn register_rollup(&self, layer: [u32; 5], rollup: [u32; 5]) -> io::Result<()> {
         // when registering a rollup layer, we need to make sure that
         // the cached version is updated as well.
+        
+        // Get the entire parent chain before registering the rollup
+        // so we can invalidate all old layers from the cache
+        let layer_stack = self.inner.retrieve_layer_stack_names(layer).await?;
+        
         self.inner.register_rollup(layer, rollup).await?;
-        self.cache.invalidate(layer);
+        
+        // Invalidate the entire parent chain from cache, not just the rolled-up layer.
+        // This ensures old layers become "dead" entries that can be cleaned up.
+        // Without this, the old parent chain stays "live" because Arc references
+        // are held by child layers.
+        for old_layer in layer_stack {
+            self.cache.invalidate(old_layer);
+        }
 
         Ok(())
     }
@@ -548,6 +605,10 @@ impl LayerStore for CachedLayerStore {
         upto: [u32; 5],
     ) -> io::Result<Vec<[u32; 5]>> {
         self.inner.retrieve_layer_stack_names_upto(name, upto).await
+    }
+
+    fn cleanup_layer_cache(&self) -> usize {
+        self.cache.cleanup_stale_entries()
     }
 }
 

--- a/src/storage/layer.rs
+++ b/src/storage/layer.rs
@@ -351,6 +351,12 @@ pub trait LayerStore: 'static + Packable + Send + Sync {
         ))
     }
 
+    /// Returns cache statistics: (total_entries, live_entries, dead_entries)
+    /// Default implementation returns (0, 0, 0) for stores without caching.
+    fn layer_cache_stats(&self) -> (usize, usize, usize) {
+        (0, 0, 0)
+    }
+
     /// Remove stale entries from the layer cache. Returns number of entries removed.
     /// Default implementation does nothing and returns 0.
     fn cleanup_layer_cache(&self) -> usize {

--- a/src/storage/layer.rs
+++ b/src/storage/layer.rs
@@ -350,6 +350,16 @@ pub trait LayerStore: 'static + Packable + Send + Sync {
             positives, negatives,
         ))
     }
+
+    /// Remove stale entries from the layer cache. Returns number of entries removed.
+    /// Default implementation does nothing and returns 0.
+    fn cleanup_layer_cache(&self) -> usize {
+        0
+    }
+
+    /// Invalidate a specific layer from the cache, forcing reload from disk on next access.
+    /// Default implementation does nothing for stores without caching.
+    fn invalidate(&self, _name: [u32; 5]) {}
 }
 
 #[async_trait]

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -900,6 +900,12 @@ impl Store {
         self.layer_store.import_layers(pack, layer_ids).await
     }
 
+    /// Returns cache statistics: (total_entries, live_entries, dead_entries)
+    /// Dead entries are stale weak references that should be cleaned up.
+    pub fn layer_cache_stats(&self) -> (usize, usize, usize) {
+        self.layer_store.layer_cache_stats()
+    }
+
     /// Remove stale entries from the layer cache. Returns number of entries removed.
     pub fn cleanup_layer_cache(&self) -> usize {
         self.layer_store.cleanup_layer_cache()

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -899,6 +899,16 @@ impl Store {
     ) -> io::Result<()> {
         self.layer_store.import_layers(pack, layer_ids).await
     }
+
+    /// Remove stale entries from the layer cache. Returns number of entries removed.
+    pub fn cleanup_layer_cache(&self) -> usize {
+        self.layer_store.cleanup_layer_cache()
+    }
+
+    /// Invalidate a specific layer from the cache, forcing reload from disk on next access.
+    pub fn invalidate_layer(&self, name: [u32; 5]) {
+        self.layer_store.invalidate(name);
+    }
 }
 
 /// Open a store that is entirely in memory.

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -605,6 +605,12 @@ impl SyncStore {
         task_sync(self.inner.layer_store.import_layers(pack, layer_ids))
     }
 
+    /// Returns cache statistics: (total_entries, live_entries, dead_entries)
+    /// Dead entries are stale weak references that should be cleaned up.
+    pub fn layer_cache_stats(&self) -> (usize, usize, usize) {
+        self.inner.layer_cache_stats()
+    }
+
     /// Remove stale entries from the layer cache. Returns number of entries removed.
     pub fn cleanup_layer_cache(&self) -> usize {
         self.inner.cleanup_layer_cache()

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -604,6 +604,16 @@ impl SyncStore {
     ) -> io::Result<()> {
         task_sync(self.inner.layer_store.import_layers(pack, layer_ids))
     }
+
+    /// Remove stale entries from the layer cache. Returns number of entries removed.
+    pub fn cleanup_layer_cache(&self) -> usize {
+        self.inner.cleanup_layer_cache()
+    }
+
+    /// Invalidate a specific layer from the cache, forcing reload from disk on next access.
+    pub fn invalidate_layer(&self, name: [u32; 5]) {
+        self.inner.invalidate_layer(name);
+    }
 }
 
 /// Open a store that is entirely in memory.


### PR DESCRIPTION
Previously, register_rollup only invalidated the single rolled-up layer from cache. This left ancestor layers cached with Arc references, causing memory accumulation and O(n) performance degradation during high commit rates with rollups.

Now traverses the full layer stack and invalidates all ancestors, ensuring old parent chains become eligible for cleanup.

Also add cache statistics which can help understand the cache better.