### PR TITLE
Foundation for range queries - reverse range queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1.0"
 async-trait = "0.1"
 itertools = "0.10"
 rug = {version="1.16", default-features=false, features=["integer","rational"]}
-num-derive = "0.3"
+num-derive = "0.4"
 num-traits = "0.2"
 chrono = "0.4"
 base64 = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "terminus-store"
-version = "0.21.6"
-authors = ["Matthijs van Otterdijk <matthijs@datachemist.com>"]
+version = "0.21.7"
+authors = ["Matthijs van Otterdijk <matthijs@datachemist.com>", "Philippe Höij <philippe.hoij@dfrnt.com>"]
 edition = "2018"
 license = "Apache-2.0"
 description = "a triple store library"
@@ -41,3 +41,4 @@ tdb-succinct = "0.1.1"
 [features]
 noreadlock = []
 eprint_log = []
+rollup_metadata_experimental = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminus-store"
-version = "0.21.5"
+version = "0.21.6"
 authors = ["Matthijs van Otterdijk <matthijs@datachemist.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/layer/internal/base.rs
+++ b/src/layer/internal/base.rs
@@ -38,6 +38,8 @@ pub struct BaseLayer {
     pub(super) o_ps_adjacency_list: AdjacencyList,
 
     pub(super) predicate_wavelet_tree: WaveletTree,
+
+    pub(super) stored_size: usize,
 }
 
 impl BaseLayer {
@@ -50,6 +52,7 @@ impl BaseLayer {
     }
 
     pub fn load(name: [u32; 5], maps: BaseLayerMaps) -> InternalLayer {
+        let stored_size = maps.byte_size();
         let node_dictionary = StringDict::parse(
             maps.node_dictionary_maps.offsets_map,
             maps.node_dictionary_maps.blocks_map,
@@ -137,6 +140,8 @@ impl BaseLayer {
             o_ps_adjacency_list,
 
             predicate_wavelet_tree,
+
+            stored_size,
         })
     }
 }

--- a/src/layer/internal/child.rs
+++ b/src/layer/internal/child.rs
@@ -49,6 +49,8 @@ pub struct ChildLayer {
 
     pub(super) pos_predicate_wavelet_tree: WaveletTree,
     pub(super) neg_predicate_wavelet_tree: WaveletTree,
+
+    pub(super) stored_size: usize,
 }
 
 impl ChildLayer {
@@ -62,6 +64,7 @@ impl ChildLayer {
     }
 
     pub fn load(name: [u32; 5], parent: Arc<InternalLayer>, maps: ChildLayerMaps) -> InternalLayer {
+        let stored_size = maps.byte_size();
         let node_dictionary = StringDict::parse(
             maps.node_dictionary_maps.offsets_map,
             maps.node_dictionary_maps.blocks_map,
@@ -193,6 +196,8 @@ impl ChildLayer {
 
             pos_predicate_wavelet_tree,
             neg_predicate_wavelet_tree,
+
+            stored_size,
         })
     }
 }

--- a/src/layer/internal/mod.rs
+++ b/src/layer/internal/mod.rs
@@ -218,6 +218,15 @@ impl InternalLayer {
         }
     }
 
+    /// Returns the byte size of this layer's own backing data (not parents).
+    pub fn stored_size(&self) -> usize {
+        match self {
+            Base(base) => base.stored_size,
+            Child(child) => child.stored_size,
+            Rollup(rollup) => rollup.internal.stored_size(),
+        }
+    }
+
     pub fn predicate_dict_get(&self, id: usize) -> Option<String> {
         self.predicate_dictionary().get(id)
     }
@@ -882,6 +891,10 @@ impl Layer for InternalLayer {
                 .seek_object(object)
                 .take_while(move |t| t.object == object),
         )
+    }
+
+    fn stored_size(&self) -> usize {
+        InternalLayer::stored_size(self)
     }
 
     fn single_triple_sp(&self, subject: u64, predicate: u64) -> Option<IdTriple> {

--- a/src/layer/internal/mod.rs
+++ b/src/layer/internal/mod.rs
@@ -951,6 +951,64 @@ impl Layer for InternalLayer {
         }))
     }
 
+    fn triples_value_range_rev(
+        &self,
+        low: &TypedDictEntry,
+        high: &TypedDictEntry,
+    ) -> Box<dyn Iterator<Item = IdTriple> + Send> {
+        if low.datatype() != high.datatype() {
+            return Box::new(std::iter::empty());
+        }
+
+        let dt = low.datatype();
+        let layers = self.immediate_layers();
+        let mut object_ids = Vec::new();
+        let mut parent_count = 0u64;
+
+        for layer in layers.iter() {
+            let node_dict_len = layer.node_dict_len() as u64;
+            let value_dict_len = layer.value_dict_len() as u64;
+
+            let value_dict = layer.value_dictionary();
+            let type_offset = match value_dict.type_segment(dt) {
+                Some((_, offset)) => offset,
+                None => {
+                    parent_count += node_dict_len + value_dict_len;
+                    continue;
+                }
+            };
+
+            let start = match value_dict.id_entry(low) {
+                IdLookupResult::Found(i) => i,
+                IdLookupResult::Closest(i) => i + 1,
+                IdLookupResult::NotFound => type_offset + 1,
+            };
+
+            let end = match value_dict.id_entry(high) {
+                IdLookupResult::Found(i) => i,
+                IdLookupResult::Closest(i) => i + 1,
+                IdLookupResult::NotFound => type_offset + 1,
+            };
+
+            let id_map = layer.node_value_id_map();
+            for pos in (start..end).rev() {
+                let inner_id = pos + node_dict_len;
+                let outer_id = id_map.inner_to_outer(inner_id);
+                let global_id = outer_id + parent_count;
+                object_ids.push(global_id);
+            }
+
+            parent_count += node_dict_len + value_dict_len;
+        }
+
+        let layer_clone = self.clone();
+        Box::new(object_ids.into_iter().flat_map(move |oid| {
+            InternalTripleObjectIterator::from_layer(&layer_clone)
+                .seek_object(oid)
+                .take_while(move |t| t.object == oid)
+        }))
+    }
+
     fn stored_size(&self) -> usize {
         InternalLayer::stored_size(self)
     }

--- a/src/layer/layer.rs
+++ b/src/layer/layer.rs
@@ -114,6 +114,16 @@ pub trait Layer: Send + Sync {
 
     fn triples_o(&self, object: u64) -> Box<dyn Iterator<Item = IdTriple> + Send>;
 
+    /// Iterator over all triples whose object value falls in the half-open range [low, high).
+    ///
+    /// Both bounds must have the same Datatype. The range is inclusive on low and exclusive on high.
+    /// Returns an empty iterator if the type segment doesn't exist or if the range is empty.
+    fn triples_value_range(
+        &self,
+        low: &TypedDictEntry,
+        high: &TypedDictEntry,
+    ) -> Box<dyn Iterator<Item = IdTriple> + Send>;
+
     /// Convert all known strings in the given string triple to ids.
     fn value_triple_to_partially_resolved(&self, triple: ValueTriple) -> PartiallyResolvedTriple {
         PartiallyResolvedTriple {

--- a/src/layer/layer.rs
+++ b/src/layer/layer.rs
@@ -163,6 +163,12 @@ pub trait Layer: Send + Sync {
     }
 
     fn single_triple_sp(&self, subject: u64, predicate: u64) -> Option<IdTriple>;
+
+    /// Returns the byte size of the backing data for this layer only (not parents).
+    /// Default returns 0 for layers that don't track this.
+    fn stored_size(&self) -> usize {
+        0
+    }
 }
 
 pub struct LayerCounts {

--- a/src/layer/layer.rs
+++ b/src/layer/layer.rs
@@ -124,6 +124,17 @@ pub trait Layer: Send + Sync {
         high: &TypedDictEntry,
     ) -> Box<dyn Iterator<Item = IdTriple> + Send>;
 
+    /// Iterator over all triples whose object value falls in the half-open range [low, high),
+    /// yielding results in reverse (descending) object order.
+    ///
+    /// Both bounds must have the same Datatype. The range is inclusive on low and exclusive on high.
+    /// Returns an empty iterator if the type segment doesn't exist or if the range is empty.
+    fn triples_value_range_rev(
+        &self,
+        low: &TypedDictEntry,
+        high: &TypedDictEntry,
+    ) -> Box<dyn Iterator<Item = IdTriple> + Send>;
+
     /// Convert all known strings in the given string triple to ids.
     fn value_triple_to_partially_resolved(&self, triple: ValueTriple) -> PartiallyResolvedTriple {
         PartiallyResolvedTriple {

--- a/src/storage/cache.rs
+++ b/src/storage/cache.rs
@@ -12,6 +12,12 @@ pub trait LayerCache: 'static + Send + Sync {
     fn cache_layer(&self, layer: Arc<InternalLayer>);
 
     fn invalidate(&self, name: [u32; 5]);
+
+    /// Remove stale entries from the cache. Returns number of entries removed.
+    /// Default implementation does nothing.
+    fn cleanup_stale_entries(&self) -> usize {
+        0
+    }
 }
 
 pub struct NoCache;
@@ -32,7 +38,13 @@ lazy_static! {
 
 // locking isn't really ideal but the lock window will be relatively small so it shouldn't hurt performance too much except on heavy updates.
 // ideally we should be using some concurrent hashmap implementation instead.
-// furthermore, there should be some logic to remove stale entries, like a periodic pass. right now, there isn't.
+
+/// Threshold for automatic cleanup: when cache size exceeds this, trigger cleanup on next cache_layer call.
+const CACHE_CLEANUP_THRESHOLD: usize = 100;
+
+/// Only cleanup if dead entries exceed this percentage of total.
+const DEAD_ENTRY_PERCENTAGE_THRESHOLD: usize = 20;
+
 #[derive(Default)]
 pub struct LockingHashMapLayerCache {
     cache: RwLock<HashMap<[u32; 5], Weak<InternalLayer>>>,
@@ -41,6 +53,16 @@ pub struct LockingHashMapLayerCache {
 impl LockingHashMapLayerCache {
     pub fn new() -> Self {
         Default::default()
+    }
+
+    /// Remove all stale (dead) weak references from the cache.
+    /// Returns the number of entries removed.
+    pub fn cleanup_stale(&self) -> usize {
+        let mut cache = self.cache.write().expect("rwlock write should always succeed, but got poisoned");
+        let before = cache.len();
+        cache.retain(|_, weak| weak.strong_count() > 0);
+        let after = cache.len();
+        before - after
     }
 }
 
@@ -74,6 +96,20 @@ impl LayerCache for LockingHashMapLayerCache {
             .cache
             .write()
             .expect("rwlock write should always succeed");
+        
+        // Automatic cleanup: when cache exceeds threshold, check for stale entries
+        let cache_size = cache.len();
+        if cache_size >= CACHE_CLEANUP_THRESHOLD {
+            // Count dead entries
+            let dead_count = cache.values().filter(|w| w.strong_count() == 0).count();
+            let dead_percentage = (dead_count * 100) / cache_size.max(1);
+            
+            // Only cleanup if dead entries exceed threshold percentage
+            if dead_percentage >= DEAD_ENTRY_PERCENTAGE_THRESHOLD {
+                cache.retain(|_, weak| weak.strong_count() > 0);
+            }
+        }
+        
         cache.insert(layer.name(), Arc::downgrade(&layer));
     }
 
@@ -85,6 +121,10 @@ impl LayerCache for LockingHashMapLayerCache {
             .expect("rwlock read should always succeed");
 
         cache.remove(&name);
+    }
+
+    fn cleanup_stale_entries(&self) -> usize {
+        self.cleanup_stale()
     }
 }
 
@@ -104,6 +144,11 @@ impl CachedLayerStore {
 
     pub fn invalidate(&self, name: [u32; 5]) {
         self.cache.invalidate(name);
+    }
+
+    /// Remove stale entries from the cache. Returns number of entries removed.
+    pub fn cleanup_stale_entries(&self) -> usize {
+        self.cache.cleanup_stale_entries()
     }
 }
 
@@ -305,8 +350,20 @@ impl LayerStore for CachedLayerStore {
     async fn register_rollup(&self, layer: [u32; 5], rollup: [u32; 5]) -> io::Result<()> {
         // when registering a rollup layer, we need to make sure that
         // the cached version is updated as well.
+        
+        // Get the entire parent chain before registering the rollup
+        // so we can invalidate all old layers from the cache
+        let layer_stack = self.inner.retrieve_layer_stack_names(layer).await?;
+        
         self.inner.register_rollup(layer, rollup).await?;
-        self.cache.invalidate(layer);
+        
+        // Invalidate the entire parent chain from cache, not just the rolled-up layer.
+        // This ensures old layers become "dead" entries that can be cleaned up.
+        // Without this, the old parent chain stays "live" because Arc references
+        // are held by child layers.
+        for old_layer in layer_stack {
+            self.cache.invalidate(old_layer);
+        }
 
         Ok(())
     }
@@ -548,6 +605,10 @@ impl LayerStore for CachedLayerStore {
         upto: [u32; 5],
     ) -> io::Result<Vec<[u32; 5]>> {
         self.inner.retrieve_layer_stack_names_upto(name, upto).await
+    }
+
+    fn cleanup_layer_cache(&self) -> usize {
+        self.cache.cleanup_stale_entries()
     }
 }
 

--- a/src/storage/layer.rs
+++ b/src/storage/layer.rs
@@ -363,6 +363,12 @@ pub trait LayerStore: 'static + Packable + Send + Sync {
         0
     }
 
+    /// Returns bytes of backing data: (total_bytes, live_bytes, dead_bytes).
+    /// Default implementation returns (0, 0, 0) for stores without caching.
+    fn layer_cache_memory_bytes(&self) -> (usize, usize, usize) {
+        (0, 0, 0)
+    }
+
     /// Invalidate a specific layer from the cache, forcing reload from disk on next access.
     /// Default implementation does nothing for stores without caching.
     fn invalidate(&self, _name: [u32; 5]) {}

--- a/src/storage/layer.rs
+++ b/src/storage/layer.rs
@@ -351,6 +351,12 @@ pub trait LayerStore: 'static + Packable + Send + Sync {
         ))
     }
 
+    /// Returns cache statistics: (total_entries, live_entries, dead_entries)
+    /// Default implementation returns (0, 0, 0) for stores without caching.
+    fn layer_cache_stats(&self) -> (usize, usize, usize) {
+        (0, 0, 0)
+    }
+
     /// Remove stale entries from the layer cache. Returns number of entries removed.
     /// Default implementation does nothing and returns 0.
     fn cleanup_layer_cache(&self) -> usize {

--- a/src/storage/layer.rs
+++ b/src/storage/layer.rs
@@ -350,6 +350,16 @@ pub trait LayerStore: 'static + Packable + Send + Sync {
             positives, negatives,
         ))
     }
+
+    /// Remove stale entries from the layer cache. Returns number of entries removed.
+    /// Default implementation does nothing and returns 0.
+    fn cleanup_layer_cache(&self) -> usize {
+        0
+    }
+
+    /// Invalidate a specific layer from the cache, forcing reload from disk on next access.
+    /// Default implementation does nothing for stores without caching.
+    fn invalidate(&self, _name: [u32; 5]) {}
 }
 
 #[async_trait]

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -654,6 +654,14 @@ impl Layer for StoreLayer {
         self.layer.triples_o(object)
     }
 
+    fn triples_value_range(
+        &self,
+        low: &TypedDictEntry,
+        high: &TypedDictEntry,
+    ) -> Box<dyn Iterator<Item = IdTriple> + Send> {
+        self.layer.triples_value_range(low, high)
+    }
+
     fn clone_boxed(&self) -> Box<dyn Layer> {
         Box::new(self.clone())
     }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -900,6 +900,12 @@ impl Store {
         self.layer_store.import_layers(pack, layer_ids).await
     }
 
+    /// Returns cache statistics: (total_entries, live_entries, dead_entries)
+    /// Dead entries are stale weak references that should be cleaned up.
+    pub fn layer_cache_stats(&self) -> (usize, usize, usize) {
+        self.layer_store.layer_cache_stats()
+    }
+
     /// Remove stale entries from the layer cache. Returns number of entries removed.
     pub fn cleanup_layer_cache(&self) -> usize {
         self.layer_store.cleanup_layer_cache()

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -899,6 +899,16 @@ impl Store {
     ) -> io::Result<()> {
         self.layer_store.import_layers(pack, layer_ids).await
     }
+
+    /// Remove stale entries from the layer cache. Returns number of entries removed.
+    pub fn cleanup_layer_cache(&self) -> usize {
+        self.layer_store.cleanup_layer_cache()
+    }
+
+    /// Invalidate a specific layer from the cache, forcing reload from disk on next access.
+    pub fn invalidate_layer(&self, name: [u32; 5]) {
+        self.layer_store.invalidate(name);
+    }
 }
 
 /// Open a store that is entirely in memory.

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -662,6 +662,14 @@ impl Layer for StoreLayer {
         self.layer.triples_value_range(low, high)
     }
 
+    fn triples_value_range_rev(
+        &self,
+        low: &TypedDictEntry,
+        high: &TypedDictEntry,
+    ) -> Box<dyn Iterator<Item = IdTriple> + Send> {
+        self.layer.triples_value_range_rev(low, high)
+    }
+
     fn clone_boxed(&self) -> Box<dyn Layer> {
         Box::new(self.clone())
     }

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -616,6 +616,16 @@ impl SyncStore {
         self.inner.cleanup_layer_cache()
     }
 
+    /// Returns bytes of backing data: (total_bytes, live_bytes, dead_bytes).
+    pub fn layer_cache_memory_bytes(&self) -> (usize, usize, usize) {
+        self.inner.layer_cache_memory_bytes()
+    }
+
+    /// Returns the current LRU archive cache usage in bytes, or None if unavailable.
+    pub fn lru_cache_used_bytes(&self) -> Option<usize> {
+        self.inner.lru_cache_used_bytes()
+    }
+
     /// Invalidate a specific layer from the cache, forcing reload from disk on next access.
     pub fn invalidate_layer(&self, name: [u32; 5]) {
         self.inner.invalidate_layer(name);

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -605,6 +605,12 @@ impl SyncStore {
         task_sync(self.inner.layer_store.import_layers(pack, layer_ids))
     }
 
+    /// Returns cache statistics: (total_entries, live_entries, dead_entries)
+    /// Dead entries are stale weak references that should be cleaned up.
+    pub fn layer_cache_stats(&self) -> (usize, usize, usize) {
+        self.inner.layer_cache_stats()
+    }
+
     /// Remove stale entries from the layer cache. Returns number of entries removed.
     pub fn cleanup_layer_cache(&self) -> usize {
         self.inner.cleanup_layer_cache()

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -626,6 +626,13 @@ impl SyncStore {
         self.inner.lru_cache_used_bytes()
     }
 
+    /// Evict LRU cache entries until usage is at or below the given
+    /// fraction of the configured limit.  Does nothing if no LRU
+    /// backend is configured.
+    pub fn evict_lru_cache(&self, target_fraction: f64) {
+        self.inner.evict_lru_cache(target_fraction)
+    }
+
     /// Invalidate a specific layer from the cache, forcing reload from disk on next access.
     pub fn invalidate_layer(&self, name: [u32; 5]) {
         self.inner.invalidate_layer(name);

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -604,6 +604,16 @@ impl SyncStore {
     ) -> io::Result<()> {
         task_sync(self.inner.layer_store.import_layers(pack, layer_ids))
     }
+
+    /// Remove stale entries from the layer cache. Returns number of entries removed.
+    pub fn cleanup_layer_cache(&self) -> usize {
+        self.inner.cleanup_layer_cache()
+    }
+
+    /// Invalidate a specific layer from the cache, forcing reload from disk on next access.
+    pub fn invalidate_layer(&self, name: [u32; 5]) {
+        self.inner.invalidate_layer(name);
+    }
 }
 
 /// Open a store that is entirely in memory.

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -621,7 +621,7 @@ impl SyncStore {
         self.inner.layer_cache_memory_bytes()
     }
 
-    /// Returns the current LRU archive cache usage in bytes, or None if unavailable.
+    /// Returns the current LRU archive cache usage in bytes, or None if no LRU backend.
     pub fn lru_cache_used_bytes(&self) -> Option<usize> {
         self.inner.lru_cache_used_bytes()
     }

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -440,6 +440,14 @@ impl Layer for SyncStoreLayer {
         self.inner.triples_o(object)
     }
 
+    fn triples_value_range(
+        &self,
+        low: &TypedDictEntry,
+        high: &TypedDictEntry,
+    ) -> Box<dyn Iterator<Item = IdTriple> + Send> {
+        self.inner.triples_value_range(low, high)
+    }
+
     fn clone_boxed(&self) -> Box<dyn Layer> {
         Box::new(self.clone())
     }

--- a/src/store/sync.rs
+++ b/src/store/sync.rs
@@ -448,6 +448,14 @@ impl Layer for SyncStoreLayer {
         self.inner.triples_value_range(low, high)
     }
 
+    fn triples_value_range_rev(
+        &self,
+        low: &TypedDictEntry,
+        high: &TypedDictEntry,
+    ) -> Box<dyn Iterator<Item = IdTriple> + Send> {
+        self.inner.triples_value_range_rev(low, high)
+    }
+
     fn clone_boxed(&self) -> Box<dyn Layer> {
         Box::new(self.clone())
     }


### PR DESCRIPTION
This is the same as the previous PR, but for getting the range in reverse.

It enables identifying the domain, limit(1) on forward and reverse, is the domain. Also, for temporal queries, going from the newest to oldest is often a great way to process a range.